### PR TITLE
fix(alunos): Corrige a criação de alunos duplicados e limpa dependências

### DIFF
--- a/backend/application/__init__.py
+++ b/backend/application/__init__.py
@@ -1,7 +1,6 @@
 from .auth import *
 from .config import *
 from .libs import *
-from .mistral import *
 from .models import *
 from .routes import *
 from .services import *

--- a/backend/application/routes/route_alunos.py
+++ b/backend/application/routes/route_alunos.py
@@ -46,7 +46,7 @@ def gerar_aluno():
     # Verifica se já existe um aluno com alguns dados que devem ser únicos
     aluno_existe = buscar_aluno(matricula=matricula, email=email, cpf=cpf)
     if aluno_existe:
-        return jsonify({"error": "Aluno com essa matrícula, email ou cpf já existe"}), 400
+        return jsonify({"error": "Aluno com essa matrícula, email ou cpf já existe"}), 409
     
     # Cria o aluno
     aluno = criar_aluno(matricula, nome, email, senha, cpf, data_nascimento)

--- a/backend/application/services/service_aluno.py
+++ b/backend/application/services/service_aluno.py
@@ -42,23 +42,33 @@ def buscar_aluno(aluno_id: uuid.UUID = None, matricula: str = None, nome: str = 
 
     Retorna um dicionário com os dados do aluno se ele existir, e None caso contrário.
     """
-    if aluno_id is not None:
+    # Se um ID específico for passado, a busca é direta e ignora os outros campos.
+    if aluno_id:
         aluno = Aluno.query.filter_by(id=aluno_id).first()
+        return aluno.to_dict() if aluno else None
     
-    if matricula is not None:
-        aluno = Aluno.query.filter_by(matricula=matricula).first()
+    # Cria uma lista de filtros baseada nos parâmetros que não são None
+    filtros = []
+
+    if matricula:
+        filtros.append(Aluno.matricula == matricula)
+
+    if email:
+        filtros.append(Aluno.email == email)
+
+    if nome:
+        filtros.append(Aluno.nome == nome)
     
-    if nome is not None:
-        aluno = Aluno.query.filter_by(nome=nome).first()
-    
-    if email is not None:
-        aluno = Aluno.query.filter_by(email=email).first()
-    
-    if cpf is not None:
-        aluno = Aluno.query.filter_by(cpf=cpf).first()
-    
-    if data_nascimento is not None:
-        aluno = Aluno.query.filter_by(data_nascimento=data_nascimento).first()
+    if cpf:
+        filtros.append(Aluno.cpf == cpf)
+
+    if data_nascimento:
+        filtros.append(Aluno.data_nascimento == data_nascimento)
+
+    aluno = None
+
+    if filtros:
+        aluno = Aluno.query.filter(db.or_(*filtros)).first()
     
     return aluno.to_dict() if aluno else None
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -14,6 +14,7 @@ selenium
 webdriver-manager
 ollama
 mistral_common
+mistral_common[sentencepiece]
 langchain
 langchain_community
 sentence-transformers


### PR DESCRIPTION
Closes #3

Este PR resolve três problemas iniciais identificados no setup e na lógica de criação de alunos.

### 1. Correção do Endpoint de Criação de Alunos

* **O Problema:** O endpoint `/alunos/criar` estava retornando um erro `500 Internal Server Error` ao tentar criar um aluno com uma `matrícula` que já existia. Observando um pouco identifiquei que a causa raiz era uma falha na lógica da função `buscar_aluno` no service, que não detectava corretamente a duplicidade antes da inserção.
* **A Solução:**
    * A função `buscar_aluno` foi refatorada para construir uma query dinâmica com `OR`, garantindo que qualquer um dos campos únicos (matrícula, email, cpf) seja verificado corretamente.
    * A rota agora retorna o status `409 Conflict`, que é mais apropriado para este tipo de erro.

### 2. Limpeza de Código e Dependências

* Removido o `import` do módulo `mistral`, que já estava depreciado, do arquivo `application/__init__.py`.
* Adicionada a dependência `sentencepiece` ao `requirements.txt` (`mistral-common[sentencepiece]`) para garantir que o ambiente seja configurado corretamente em futuras instalações.