### PR TITLE
feat(k8s): Adiciona manifestos e documentação para deploy com Kubernetes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,89 +1,123 @@
 # Tutor
 
-Guia de configuração para o ambiente de desenvolvimento e produção do projeto.
+Guia de configuração para os ambientes de desenvolvimento e produção do projeto.
 
 ## Stack de Tecnologias
 
-- **Frontend:** JavaScript com [Next.js](https://nextjs.org/) e React.
-- **Backend:** Python com [Flask](https://flask.palletsprojects.com/) e [Gunicorn](https://gunicorn.org/) para produção.
-- **Banco de Dados:** [PostgreSQL](https://www.postgresql.org/).
-- **LLM:** Integração com modelos de linguagem via [Ollama](https://ollama.com/).
-- **Ambiente:** Totalmente containerizado com [Docker](https://www.docker.com/) e [Docker Compose](https://docs.docker.com/compose/).
+* **Frontend:** JavaScript com [Next.js](https://nextjs.org/) e React.
+* **Backend:** Python com [Flask](https://flask.palletsprojects.com/) e [Gunicorn](https://gunicorn.org/) para produção.
+* **Banco de Dados:** [PostgreSQL](https://www.postgresql.org/).
+* **LLM:** Integração com modelos de linguagem via [Ollama](https://ollama.com/).
+* **Ambiente:** Totalmente containerizado com [Docker](https://www.docker.com/).
+* **Orquestração:** Deploy em [Kubernetes](https://kubernetes.io/) para simulação de produção.
 
-## Como Rodar o Projeto
+---
 
-O ambiente é 100% containerizado com Docker, simplificando a configuração para desenvolvimento e produção.
+## 🚀 Como Rodar o Projeto
 
-### Pré-requisitos
+Existem duas maneiras de rodar a aplicação: usando **Docker Compose** para um ambiente de desenvolvimento rápido com hot-reload, ou usando **Kubernetes** para simular um deploy de produção completo.
 
-- [Git](https://git-scm.com/)
-- [Docker Desktop](https://www.docker.com/products/docker-desktop/)
-- [Ollama](https://ollama.com/download)
+### Pré-requisitos Gerais
 
-_Nota: Atualmente, o serviço da LLM (Ollama) precisa ser executado na máquina local. Após instalar o Ollama, baixe o modelo `mistral` que o projeto utiliza com o seguinte comando:_
+Antes de começar, garanta que você tenha os seguintes softwares instalados:
 
+* [Git](https://git-scm.com/)
+* [Docker Desktop](https://www.docker.com/products/docker-desktop/) (com o Kubernetes ativado nas configurações)
+* [Ollama](https://ollama.com/download)
+
+*Nota: Atualmente, o serviço da LLM (Ollama) precisa ser executado na máquina local. Após instalar o Ollama, baixe o modelo `mistral` que o projeto utiliza:*
 ```bash
 ollama pull mistral
-```
+````
 
-### Configuração e Execução
+### Configuração Inicial (Comum aos dois ambientes)
 
 1.  **Clone o Repositório:**
 
     ```bash
-    git clone https://github.com/fabrica-bayarea/Tutor.git
+    git clone [https://github.com/fabrica-bayarea/Tutor.git](https://github.com/fabrica-bayarea/Tutor.git)
     cd Tutor
     ```
 
-2.  **Crie o Arquivo de Ambiente Principal (`./.env`):**
+2.  **Crie os Arquivos `.env`:**
 
-    - Na **raiz do projeto**, crie um arquivo chamado `.env`.
-    - Adicione a senha que será usada pelo banco de dados:
+      * **Arquivo Principal (`./.env`):** Crie este arquivo na raiz do projeto com a senha do banco de dados.
+        ```
+        # Arquivo: ./.env
+        POSTGRES_PASSWORD=sua_senha_segura_aqui
+        ```
+      * **Arquivo do Backend (`./backend/.env`):** Crie este arquivo dentro da pasta `backend/`. A senha deve ser a mesma do passo anterior.
+        ```
+        # Arquivo: ./backend/.env
+        SECRET_KEY=gere_uma_chave_secreta_aqui
+        DATABASE_URL=postgresql://postgres:${POSTGRES_PASSWORD}@db:5432/tutor
+        DB_HOST=db
+        FLASK_DEBUG=1
+        ```
 
-    ```
-    # Arquivo: ./.env
-    POSTGRES_PASSWORD=sua_senha_segura_aqui
-    ```
+-----
 
-3.  **Crie o Arquivo de Ambiente do Backend (`./backend/.env`):**
+### Método 1: Docker Compose (Ambiente de Desenvolvimento)
 
-    - Dentro da pasta `backend/`, crie outro arquivo chamado `.env`.
-    - **IMPORTANTE:** O `POSTGRES_PASSWORD` deve ser o mesmo que você definiu no passo anterior.
-
-    ```
-    # Arquivo: ./backend/.env
-    SECRET_KEY=gere_uma_chave_secreta_aqui
-    DATABASE_URL=postgresql://postgres:${POSTGRES_PASSWORD}@db:5432/tutor
-    DB_HOST=db
-    # Opcional para desenvolvimento backend:
-    FLASK_DEBUG=1
-    ```
-
-### Executando os Ambientes
-
-Com o Docker Desktop e o Ollama em execução, você pode iniciar os containers.
-
-#### Ambiente de Desenvolvimento
 Ideal para codificar, pois possui **hot-reload** (as alterações no código são aplicadas automaticamente).
+
+**Execute o comando:**
 
 ```bash
 # Na raiz do projeto, execute:
 docker-compose up --build
 ```
-#### Ambiente de Produção
-Simula o ambiente real de produção, usando o servidor Gunicorn (backend) e o build otimizado do Next.js. Não possui hot-reload.
+
+-----
+
+### Método 2: Kubernetes (Simulando Deploy de Produção)
+
+Este método faz o deploy da aplicação em um cluster Kubernetes local, da mesma forma que seria feito em um ambiente de produção na nuvem.
+
+**1. Crie o Segredo do Banco de Dados:**
+Para evitar expor senhas nos arquivos de configuração, o segredo do banco é criado com o seguinte comando. (Lembre-se de adicionar `postgres-secrets.env` ao seu `.gitignore`\!).
+
+  * Crie um arquivo `postgres-secrets.env` na raiz com o conteúdo: `POSTGRES_PASSWORD=sua_senha_segura_aqui`
+  * Execute o comando:
+    ```bash
+    kubectl create secret generic postgres-secret --from-env-file=postgres-secrets.env
+    ```
+    *Nota: Se o segredo já existir, você precisará deletá-lo primeiro com `kubectl delete secret postgres-secret`.*
+
+**2. Faça o Deploy da Aplicação:**
+Aplique todos os manifestos de configuração contidos na pasta `k8s/`:
 
 ```bash
-# Na raiz do projeto, execute:
-docker-compose -f docker-compose.prod.yml up --build
+kubectl apply -f k8s/
 ```
+
+**3. Verifique o Status:**
+Aguarde alguns minutos e verifique se todos os pods estão com o status `Running`:
+
+```bash
+kubectl get pods
+```
+
+-----
 
 ### Acessando a Aplicação
 
-- **Frontend:** [http://localhost:3000](http://localhost:3000)
-- **Backend API:** [http://localhost:5000](http://localhost:5000)
+  * **Frontend:** [http://localhost:3000](https://www.google.com/search?q=http://localhost:3000) (para Docker Compose) ou [http://localhost](https://www.google.com/search?q=http://localhost) (para Kubernetes).
+  * **Backend API:** [http://localhost:5000](https://www.google.com/search?q=http://localhost:5000) (para Docker Compose) ou use `kubectl port-forward service/backend-service 5001:5000` para testar no Kubernetes.
 
 ### Parando a Aplicação
 
-- Para parar todos os containers, pressione `Ctrl + C` no terminal.
-- Para remover os containers (mas manter os dados do banco), use `docker-compose down` (adicione -f docker-compose.prod.yml se estiver no ambiente de produção).
+  * **Docker Compose:** Pressione `Ctrl + C` no terminal e depois `docker-compose down`.
+  * **Kubernetes:** Execute `kubectl delete -f k8s/`.
+
+-----
+
+## Tecnologias Utilizadas
+
+  * **Docker:** É uma plataforma de containerização usada para empacotar a aplicação e suas dependências em "containers". O objetivo é criar um ambiente padronizado e isolado, resolvendo o clássico problema "mas na minha máquina funciona" e simplificando drasticamente a configuração inicial do projeto.
+
+  * **Kubernetes (K8s):** É um orquestrador de containers. Uma vez que temos nossas aplicações em containers Docker, o Kubernetes é responsável por gerenciá-las em escala. Ele automatiza o deploy, o escalonamento (criando mais cópias se a demanda aumentar) e a resiliência (substituindo containers que falham), sendo a ferramenta padrão para rodar aplicações em produção.
+
+  * **Next.js:** É um framework React para construir o frontend da aplicação. Ele foi escolhido por oferecer recursos avançados como Server-Side Rendering (SSR) e otimização de build, que resultam em uma aplicação web mais rápida e com melhor performance para o usuário final.
+
+  * **LLM Mistral (via Ollama):** É o Modelo de Linguagem Grande (Large Language Model) que serve como o "cérebro" do nosso chatbot. Ele é responsável por entender as perguntas dos alunos e gerar respostas coerentes com base nos materiais de estudo. Utilizamos o Ollama para facilitar a execução deste modelo no ambiente de desenvolvimento local.

--- a/backend/README.md
+++ b/backend/README.md
@@ -12,24 +12,24 @@ Por favor, consulte o **[README.md principal na raiz do projeto](../README.md)**
 
 Estamos usando uma **arquitetura modular baseada em camadas**, onde cada camada tem um propósito específico.
 
-```
+```bash
 Tutor/
 └── backend/
-    ├── application/
-    │   ├── auth/          # Contém códigos de autenticação
-    │   ├── config/        # Define configurações globais da aplicação
-    │   ├── libs/          # Contém códigos de bibliotecas auxiliares
-    │   ├── models/        # Define as entidades do banco de dados PostgreSQL
-    │   ├── routes/        # Define os endpoints da API Flask
-    │   ├── services/      # Contém regras de negócio e interações com os bancos
-    │   ├── socket/        # Configurações do Flask-SocketIO
-    │   └── utils/         # Contém funções genéricas
-    ├── migrations/      # Arquivos de controle de migração do Flask-Migrate
-    ├── .env             # Arquivo de variáveis de ambiente (local)
-    ├── app.py           # Inicialização da aplicação Flask
-    ├── Dockerfile       # Instruções para construir a imagem Docker do backend
-    ├── entrypoint.sh    # Script de inicialização do container
-    └── requirements.txt # Arquivo de dependências do backend
+├── application/
+│   ├── auth/          \# Contém códigos de autenticação
+│   ├── config/        \# Define configurações globais da aplicação
+│   ├── libs/          \# Contém códigos de bibliotecas auxiliares
+│   ├── models/        \# Define as entidades do banco de dados PostgreSQL
+│   ├── routes/        \# Define os endpoints da API Flask
+│   ├── services/      \# Contém regras de negócio e interações com os bancos
+│   ├── socket/        \# Configurações do Flask-SocketIO
+│   └── utils/         \# Contém funções genéricas
+├── migrations/      \# Arquivos de controle de migração do Flask-Migrate
+├── .env             \# Arquivo de variáveis de ambiente (local)
+├── app.py           \# Inicialização da aplicação Flask
+├── Dockerfile       \# Instruções para construir a imagem Docker do backend
+├── entrypoint.sh    \# Script de inicialização do container
+└── requirements.txt \# Arquivo de dependências do backend
 ```
 
 **Por questões de segurança, os arquivos `.env` não são (e nem devem) ser enviados para o repositório.**

--- a/k8s/backend.yaml
+++ b/k8s/backend.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend-deployment
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: backend
+  template:
+    metadata:
+      labels:
+        app: backend
+    spec:
+      containers:
+        - name: backend
+          image: luizfsilvano/tutor-backend:latest
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 5000
+          env:
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-secret
+                  key: POSTGRES_PASSWORD
+            - name: DATABASE_URL
+              value: "postgresql://postgres:$(DB_PASSWORD)@postgres-service:5432/tutor"
+            - name: DB_HOST
+              value: "postgres-service"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: backend-service
+spec:
+  selector:
+    app: backend
+  ports:
+    - protocol: TCP
+      port: 5000
+      targetPort: 5000

--- a/k8s/database.yaml
+++ b/k8s/database.yaml
@@ -1,0 +1,64 @@
+apiVersion: v1
+kind: PersistentVolumeClaim # O "pedido" por espaço em disco
+metadata:
+  name: postgres-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce # O volume só pode ser usado por um nó de cada vez
+  resources:
+    requests:
+      storage: 1Gi # Pede 1 Gigabyte de armazenamento
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres-deployment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:16-alpine
+          ports:
+            - containerPort: 5432
+          env:
+            - name: POSTGRES_DB
+              value: "tutor"
+            - name: POSTGRES_USER
+              value: "postgres"
+            - name: POSTGRES_PASSWORD_FILE
+              value: "/etc/postgres-secrets/POSTGRES_PASSWORD"
+          volumeMounts:
+            - name: postgres-storage # Monta o volume de dados
+              mountPath: /var/lib/postgresql/data
+            - name: postgres-secrets-volume # Monta o volume da senha
+              mountPath: /etc/postgres-secrets
+              readOnly: true
+      volumes:
+        - name: postgres-storage # Define o volume de dados usando o PVC
+          persistentVolumeClaim:
+            claimName: postgres-pvc
+        - name: postgres-secrets-volume # Define o volume da senha
+          secret:
+            secretName: postgres-secret
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres-service
+spec:
+  selector:
+    app: postgres
+  ports:
+    - protocol: TCP
+      port: 5432
+      targetPort: 5432

--- a/k8s/frontend.yaml
+++ b/k8s/frontend.yaml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend-deployment
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: frontend
+  template:
+    metadata:
+      labels:
+        app: frontend
+    spec:
+      containers:
+        - name: frontend
+          image: luizfsilvano/tutor-frontend:latest
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 3000
+          env:
+            - name: NEXT_PUBLIC_API_URL
+              value: "http://backend-service:5000" # URL do backend
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend-service
+spec:
+  selector:
+    app: frontend
+  type: LoadBalancer
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 3000


### PR DESCRIPTION
Closes #6

Este PR introduz a capacidade de fazer o deploy da aplicação completa (Backend, Frontend e Banco de Dados) em um ambiente Kubernetes, seguindo o tutorial e os requisitos da issue.

Todo o processo foi validado utilizando um cluster Kubernetes local (via Docker Desktop).

### O que foi feito:

* **Publicação de Imagens:** As imagens Docker do backend e frontend foram enviadas para um registro remoto (Docker Hub) para que o cluster possa baixá-las.
* **Manifestos Kubernetes:** Foi criada uma nova pasta `k8s/` contendo os arquivos de manifesto (`.yaml`) para os três serviços:
    * **PostgreSQL:** Inclui um `Secret` para a senha (criado de forma imperativa), um `Deployment` e um `PersistentVolumeClaim` para garantir a persistência dos dados.
    * **Backend:** Um `Deployment` com 3 réplicas que se conecta ao serviço do banco e utiliza o `Secret` para autenticação.
    * **Frontend:** Um `Deployment` com 3 réplicas e um `Service` do tipo `LoadBalancer` para expor a aplicação externamente.
* **Documentação:**
    * O `README.md` principal foi completamente reescrito para incluir as instruções de setup para os ambientes de Docker Compose (desenvolvimento) e Kubernetes (produção local).
    * Adicionada uma nova seção "Tecnologias Utilizadas" explicando o papel do Docker, Kubernetes, Next.js e Ollama no projeto.

### Como Testar:

1.  Garanta que o Kubernetes do Docker Desktop esteja ativo.
2.  Crie o segredo do banco de dados com o comando:
    ```bash
    kubectl create secret generic postgres-secret --from-env-file=postgres-secrets.env
    ```
3.  Aplique todos os manifestos na pasta `k8s/`:
    ```bash
    kubectl apply -f k8s/
    ```
4.  Verifique se todos os pods estão com o status `Running`:
    ```bash
    kubectl get pods
    ```
5.  Verifique o serviço do frontend para obter o endereço de acesso:
    ```bash
    kubectl get service frontend-service
    ```
6.  Acesse a aplicação no navegador via `http://localhost`.

### Nota sobre as Imagens
Conforme a issue, as imagens nos arquivos YAML estão apontando para uma conta pessoal do Docker Hub (`luizfsilvano/...`) para fins de teste e validação deste PR. Para o deploy final na AWS, estes endereços deverão ser substituídos pela URI do nosso repositório no ECR.