### PR TITLE
Fix/correcoes gerais

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,14 @@
 # Segurança
 SECRET_KEY=your_secret_key_here
 
+# Sessão (expiração por inatividade — sliding)
+SESSION_IDLE_MINUTES=60
+COOKIE_SECURE=false          # true em produção (HTTPS)
+COOKIE_SAMESITE=Lax          # None (com COOKIE_SECURE=true) se front/back em domínios diferentes
+
+# Redis (denylist de tokens de logout). Sem este valor, usa fallback em memória.
+REDIS_URL=redis://redis-service:6379/0
+
 # Banco de dados
 POSTGRES_PASSWORD=change_your_password
 DATABASE_URL=postgresql://postgres:change_your_password@postgres-service:5432/tutor

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+* text=auto
+
+# Shell scripts must keep LF endings to run inside Linux containers
+*.sh text eol=lf
+entrypoint.sh text eol=lf

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -463,7 +463,7 @@ jobs:
             -Dsonar.coverage.exclusions=frontend/**,**/tests/**,**/test_*.py,**/*_test.py,**/__init__.py,**/migrations/**
             -Dsonar.python.version=3.11
             -Dsonar.javascript.lcov.reportPaths=frontend/coverage/lcov.info
-            -Dsonar.python.coverage.reportPaths=backend/coverage.xml
+            -Dsonar.python.coverage.reportPaths=backend/application/coverage.xml
             -Dsonar.qualitygate.wait=true
 
       # =====================================================

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -199,13 +199,20 @@ jobs:
 
       - name: Run backend tests
         continue-on-error: true
-        working-directory: ./backend/application
+        working-directory: ./backend
         run: |
           pip install pytest pytest-cov
-          pytest tests/ \
+          # Rodamos a partir de ./backend para que `--cov=application` resolva o
+          # pacote no início da medição (de dentro de ./backend/application o
+          # coverage não encontra `application` e mede 0). O relatório fica em
+          # backend/coverage.xml, que é o caminho lido pelo SonarCloud.
+          pytest application/tests/ \
             --cov=application \
             --cov-report=xml:coverage.xml \
+            --cov-report=term \
             -q || true
+          echo "--- coverage.xml gerado: ---"
+          ls -l coverage.xml || echo "coverage.xml NAO foi gerado"
 
       # =====================================================
       # SCA — npm audit (frontend)
@@ -463,7 +470,7 @@ jobs:
             -Dsonar.coverage.exclusions=frontend/**,**/tests/**,**/test_*.py,**/*_test.py,**/__init__.py,**/migrations/**
             -Dsonar.python.version=3.11
             -Dsonar.javascript.lcov.reportPaths=frontend/coverage/lcov.info
-            -Dsonar.python.coverage.reportPaths=backend/application/coverage.xml
+            -Dsonar.python.coverage.reportPaths=backend/coverage.xml
             -Dsonar.qualitygate.wait=true
 
       # =====================================================

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -201,16 +201,21 @@ jobs:
         continue-on-error: true
         working-directory: ./backend
         run: |
-          pip install pytest pytest-cov
-          # Rodamos a partir de ./backend para que `--cov=application` resolva o
-          # pacote no início da medição (de dentro de ./backend/application o
+          pip install pytest pytest-cov coverage
+          # Rodamos a partir de ./backend para que `--source=application` resolva
+          # o pacote no início da medição (de dentro de ./backend/application o
           # coverage não encontra `application` e mede 0). O relatório fica em
           # backend/coverage.xml, que é o caminho lido pelo SonarCloud.
-          pytest application/tests/ \
-            --cov=application \
-            --cov-report=xml:coverage.xml \
-            --cov-report=term \
-            -q || true
+          #
+          # Usamos `coverage run` + `coverage xml` (em vez de pytest-cov) para que
+          # o relatório seja gravado mesmo quando o pytest sai com código != 0:
+          # parte dos testes depende de um Postgres que este job não sobe, e há um
+          # teste legado que erra na coleta (--continue-on-collection-errors evita
+          # que ele aborte a suíte inteira).
+          coverage run --source=application -m pytest application/tests/ \
+            --continue-on-collection-errors -p no:cacheprovider -q || true
+          coverage xml -o coverage.xml || true
+          coverage report || true
           echo "--- coverage.xml gerado: ---"
           ls -l coverage.xml || echo "coverage.xml NAO foi gerado"
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -212,8 +212,12 @@ jobs:
           # parte dos testes depende de um Postgres que este job não sobe, e há um
           # teste legado que erra na coleta (--continue-on-collection-errors evita
           # que ele aborte a suíte inteira).
+          #
+          # `-s` (sem captura) evita um crash de teardown da captura do pytest
+          # (gevent/socket.io fecha descritores ao final), que abortava a sessão
+          # antes de os testes rodarem; a cobertura é salva pelo coverage de qualquer forma.
           coverage run --source=application -m pytest application/tests/ \
-            --continue-on-collection-errors -p no:cacheprovider -q || true
+            --continue-on-collection-errors -p no:cacheprovider -s -q || true
           coverage xml -o coverage.xml || true
           coverage report || true
           echo "--- coverage.xml gerado: ---"

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -31,6 +31,14 @@ COPY --from=build /app .
 COPY entrypoint.sh ./entrypoint.sh
 RUN chmod +x ./entrypoint.sh
 
+# Executa como usuário não-root (mitiga risco de rodar como root no container).
+# Cria /data (volume do ChromaDB) e dá posse de /app e /data ao usuário, pois o
+# app executa os.makedirs("/data/chroma") no boot e o entrypoint precisa rodar.
+RUN useradd --create-home --uid 1000 appuser \
+    && mkdir -p /data/chroma \
+    && chown -R appuser:appuser /app /data
+USER appuser
+
 # Use o caminho relativo direto ou absoluto
 ENTRYPOINT ["/app/entrypoint.sh"]
 # Comando padrão para rodar a aplicação

--- a/backend/Dockerfile.dev
+++ b/backend/Dockerfile.dev
@@ -9,6 +9,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         build-essential \
         libpq-dev \
         netcat-openbsd \
+        libxcb1 \
+        libgl1 \
+        libglib2.0-0 \
+        libsm6 \
+        libxext6 \
+        libxrender1 \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app

--- a/backend/Dockerfile.dev
+++ b/backend/Dockerfile.dev
@@ -9,12 +9,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         build-essential \
         libpq-dev \
         netcat-openbsd \
-        libxcb1 \
-        libgl1 \
-        libglib2.0-0 \
-        libsm6 \
-        libxext6 \
-        libxrender1 \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
@@ -25,6 +19,18 @@ RUN pip install --no-cache-dir \
 
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
+
+# Bibliotecas de sistema exigidas em runtime pelo Docling para processar PDFs
+# (libxcb.so.1, libGL.so.1, etc). Ficam após o pip para não invalidar o cache
+# das camadas pesadas (torch/requirements) quando esta lista mudar.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        libxcb1 \
+        libgl1 \
+        libglib2.0-0 \
+        libsm6 \
+        libxext6 \
+        libxrender1 \
+    && rm -rf /var/lib/apt/lists/*
 
 EXPOSE 5000
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,9 +1,10 @@
-from flask import Flask
+from flask import Flask, g
 from flask_migrate import Migrate
 from flask_cors import CORS
 
 from application.config.config import Config
 from application.config.database import init_db, db
+from application.auth.jwt_handler import definir_cookie_sessao
 from application.socket.socket_instance import socketio
 from application.routes.route_auth import auth_bp
 
@@ -42,6 +43,19 @@ def add_security_headers(response):
     response.headers["Pragma"] = "no-cache"
     response.headers["Expires"] = "0"
 
+    return response
+
+
+@app.after_request
+def renovar_sessao(response):
+    """
+    Renova o cookie de sessão (sliding expiration) sempre que uma requisição
+    autenticada definir `g.refresh_token` no `token_obrigatorio`. Rotas como o
+    logout limpam `g.refresh_token` para não reabrir a sessão.
+    """
+    novo_token = getattr(g, "refresh_token", None)
+    if novo_token:
+        definir_cookie_sessao(response, novo_token)
     return response
 
 init_db(app)

--- a/backend/application/auth/auth_decorators.py
+++ b/backend/application/auth/auth_decorators.py
@@ -69,10 +69,13 @@ def apenas_admins(f):
 def apenas_professores(f):
     """
     Decorador personalizado que restringe o acesso da rota apenas para usuários com papel de professor.
+
+    O claim `role` do JWT guarda o nome do papel (RoleEnum.name), por isso a
+    comparação é com 'PROFESSOR' — alinhada a `apenas_admins` (GAP-01-A).
     """
     @wraps(f)
     def wrapper(*args, **kwargs):
-        if not hasattr(g, "usuario_role") or g.usuario_role not in ['1', '2']:
+        if not hasattr(g, "usuario_role") or g.usuario_role != "PROFESSOR":
             return jsonify({"error": "Acesso negado"}), 403
         return f(*args, **kwargs)
     return wrapper
@@ -80,10 +83,13 @@ def apenas_professores(f):
 def apenas_alunos(f):
     """
     Decorador personalizado que restringe o acesso da rota apenas para usuários com papel de aluno.
+
+    Compara contra o nome do papel ('ALUNO'), como gravado no claim `role` do
+    JWT (GAP-01-A).
     """
     @wraps(f)
     def wrapper(*args, **kwargs):
-        if not hasattr(g, "usuario_role") or g.usuario_role != "3":
+        if not hasattr(g, "usuario_role") or g.usuario_role != "ALUNO":
             return jsonify({"error": "Acesso negado"}), 403
         return f(*args, **kwargs)
     return wrapper

--- a/backend/application/auth/auth_decorators.py
+++ b/backend/application/auth/auth_decorators.py
@@ -2,7 +2,7 @@ from functools import wraps
 from flask import request, jsonify, g
 from .jwt_handler import validar_token, gerar_token
 # Denylist persistente (Redis com fallback em memória) — ver token_denylist.py.
-from .token_denylist import invalidar_token, token_invalido
+from .token_denylist import invalidar_token, token_invalido, usuario_bloqueado
 
 
 def extrair_token():
@@ -45,6 +45,11 @@ def token_obrigatorio(f):
 
         g.usuario_id = payload.get("user_id")
         g.usuario_role = payload.get("role")
+
+        # GAP-02-B: usuário desativado tem a sessão encerrada na próxima requisição.
+        if usuario_bloqueado(g.usuario_id):
+            return jsonify({"error": "Sessão encerrada. Conta desativada."}), 401
+
         g.refresh_token = gerar_token(g.usuario_id, g.usuario_role)
         return f(*args, **kwargs)
     return wrapper

--- a/backend/application/auth/auth_decorators.py
+++ b/backend/application/auth/auth_decorators.py
@@ -1,9 +1,9 @@
 from functools import wraps
 from flask import request, jsonify, g
-from .jwt_handler import validar_token
+from .jwt_handler import validar_token, gerar_token
+# Denylist persistente (Redis com fallback em memória) — ver token_denylist.py.
+from .token_denylist import invalidar_token, token_invalido
 
-
-TOKENS_INVALIDADOS = set()
 
 def extrair_token():
 
@@ -20,33 +20,32 @@ def extrair_token():
     return None
 
 
-def invalidar_token(token):
-    TOKENS_INVALIDADOS.add(token)
-
-
-def token_invalido(token):
-    return token in TOKENS_INVALIDADOS
-
-
 def token_obrigatorio(f):
     """
     Decorador personalizado que verifica se um token JWT válido foi enviado numa requisição.
+
+    Em caso de sucesso, agenda a renovação da sessão (sliding expiration): grava
+    em `g.refresh_token` um token novo com a janela de inatividade reiniciada,
+    que o `after_request` reescreve no cookie. Assim, cada requisição autenticada
+    estende a sessão; após o período de inatividade configurado, o token expira
+    e a próxima requisição recebe 401.
     """
     @wraps(f)
     def wrapper(*args, **kwargs):
         token = extrair_token()
         if not token:
             return jsonify({"error": "Token ausente"}), 401
-        
+
         if token_invalido(token):
             return jsonify({"Error": "Token invalido"}), 401
-        
+
         payload = validar_token(token)
         if not payload:
             return jsonify({"error": "Token inválido ou expirado"}), 401
-        
+
         g.usuario_id = payload.get("user_id")
         g.usuario_role = payload.get("role")
+        g.refresh_token = gerar_token(g.usuario_id, g.usuario_role)
         return f(*args, **kwargs)
     return wrapper
 

--- a/backend/application/auth/auth_decorators.py
+++ b/backend/application/auth/auth_decorators.py
@@ -2,7 +2,7 @@ from functools import wraps
 from flask import request, jsonify, g
 from .jwt_handler import validar_token, gerar_token
 # Denylist persistente (Redis com fallback em memória) — ver token_denylist.py.
-from .token_denylist import invalidar_token, token_invalido, usuario_bloqueado
+from .token_denylist import token_invalido, usuario_bloqueado
 
 
 def extrair_token():

--- a/backend/application/auth/jwt_handler.py
+++ b/backend/application/auth/jwt_handler.py
@@ -1,18 +1,32 @@
+import os
 import jwt
 import datetime
 from flask import current_app
 
-def gerar_token(user_id: str, role: str, expiracao_min=60) -> str:
+# Tempo de inatividade (em minutos) após o qual a sessão expira. Configurável
+# via .env (US-01-RNF3 / US-05-RN2). A renovação por atividade (sliding) é feita
+# em `token_obrigatorio` + `after_request`.
+SESSION_IDLE_MINUTES = int(os.getenv("SESSION_IDLE_MINUTES", 60))
+# Atributos do cookie de sessão, configuráveis por ambiente.
+COOKIE_SECURE = os.getenv("COOKIE_SECURE", "false").lower() == "true"
+COOKIE_SAMESITE = os.getenv("COOKIE_SAMESITE", "Lax")
+
+
+def gerar_token(user_id: str, role: str, expiracao_min: int | None = None) -> str:
     """
     Gera um JWT contendo o ID do usuário e seu papel ('professor' ou 'aluno').
 
     Espera receber:
         - `user_id`: str - o ID do usuário
         - `role`: str - o papel do usuário ('professor' ou 'aluno')
-        - `expiracao_min`: int - a expiração do token em minutos (por padrão, 60 minutos)
-    
+        - `expiracao_min`: int | None - expiração do token em minutos. Se None,
+          usa `SESSION_IDLE_MINUTES` (valor configurável da plataforma).
+
     Retorna o token JWT gerado.
     """
+    if expiracao_min is None:
+        expiracao_min = SESSION_IDLE_MINUTES
+
     payload = {
         "user_id": str(user_id),
         "role": role,
@@ -20,6 +34,24 @@ def gerar_token(user_id: str, role: str, expiracao_min=60) -> str:
     }
     token = jwt.encode(payload, current_app.config["SECRET_KEY"], algorithm="HS256")
     return token
+
+
+def definir_cookie_sessao(response, token: str):
+    """
+    Escreve o cookie de sessão (httponly) na resposta, com `max_age` alinhado ao
+    tempo de inatividade configurado. Fonte única para login, primeiro acesso e
+    renovação por atividade.
+    """
+    response.set_cookie(
+        "token",
+        token,
+        httponly=True,
+        secure=COOKIE_SECURE,
+        samesite=COOKIE_SAMESITE,
+        max_age=SESSION_IDLE_MINUTES * 60,
+        path="/",
+    )
+    return response
 
 def validar_token(token: str) -> dict | None:
     """

--- a/backend/application/auth/token_denylist.py
+++ b/backend/application/auth/token_denylist.py
@@ -1,0 +1,68 @@
+"""
+Denylist de tokens encerrados (logout).
+
+Usa Redis quando `REDIS_URL` está configurado — o que torna a invalidação
+persistente entre reinícios e compartilhada entre workers. Cada entrada recebe
+TTL igual ao tempo de sessão, de modo que a chave expira sozinha (a lista não
+cresce indefinidamente). Sem `REDIS_URL`, recai para um `set()` em memória
+(suficiente para desenvolvimento com 1 worker).
+"""
+import os
+import logging
+
+from .jwt_handler import SESSION_IDLE_MINUTES
+
+logger = logging.getLogger(__name__)
+
+_PREFIXO = "denylist:"
+_TTL = SESSION_IDLE_MINUTES * 60
+
+_redis = None
+_init_done = False
+_memoria = set()
+
+
+def _get_redis():
+    """Inicializa o cliente Redis uma única vez. Retorna None se indisponível."""
+    global _redis, _init_done
+    if _init_done:
+        return _redis
+
+    _init_done = True
+    url = os.getenv("REDIS_URL")
+    if not url:
+        return None
+
+    try:
+        import redis
+        client = redis.from_url(url, socket_connect_timeout=2, socket_timeout=2)
+        client.ping()
+        _redis = client
+    except Exception as e:
+        logger.warning("Redis indisponível (%s). Usando denylist em memória.", e)
+        _redis = None
+
+    return _redis
+
+
+def invalidar_token(token: str) -> None:
+    """Marca um token como inválido (logout), com expiração automática."""
+    client = _get_redis()
+    if client:
+        try:
+            client.setex(f"{_PREFIXO}{token}", _TTL, "1")
+            return
+        except Exception as e:
+            logger.warning("Falha ao gravar denylist no Redis (%s). Fallback memória.", e)
+    _memoria.add(token)
+
+
+def token_invalido(token: str) -> bool:
+    """Indica se o token foi encerrado e não deve mais ser aceito."""
+    client = _get_redis()
+    if client:
+        try:
+            return client.exists(f"{_PREFIXO}{token}") == 1
+        except Exception as e:
+            logger.warning("Falha ao ler denylist no Redis (%s). Fallback memória.", e)
+    return token in _memoria

--- a/backend/application/auth/token_denylist.py
+++ b/backend/application/auth/token_denylist.py
@@ -15,11 +15,13 @@ from .jwt_handler import SESSION_IDLE_MINUTES
 logger = logging.getLogger(__name__)
 
 _PREFIXO = "denylist:"
+_PREFIXO_USUARIO = "bloqueado:"
 _TTL = SESSION_IDLE_MINUTES * 60
 
 _redis = None
 _init_done = False
 _memoria = set()
+_memoria_usuarios = set()
 
 
 def _get_redis():
@@ -66,3 +68,45 @@ def token_invalido(token: str) -> bool:
         except Exception as e:
             logger.warning("Falha ao ler denylist no Redis (%s). Fallback memória.", e)
     return token in _memoria
+
+
+def bloquear_usuario(usuario_id: str) -> None:
+    """
+    Encerra as sessões ativas de um usuário (US-09-RV2 / GAP-02-B): qualquer token
+    dele passa a ser recusado em `token_obrigatorio` até a chave expirar (TTL = janela
+    de sessão) ou o usuário ser reativado.
+    """
+    usuario_id = str(usuario_id)
+    client = _get_redis()
+    if client:
+        try:
+            client.setex(f"{_PREFIXO_USUARIO}{usuario_id}", _TTL, "1")
+            return
+        except Exception as e:
+            logger.warning("Falha ao bloquear usuário no Redis (%s). Fallback memória.", e)
+    _memoria_usuarios.add(usuario_id)
+
+
+def desbloquear_usuario(usuario_id: str) -> None:
+    """Reabilita as sessões de um usuário (ao reativá-lo)."""
+    usuario_id = str(usuario_id)
+    client = _get_redis()
+    if client:
+        try:
+            client.delete(f"{_PREFIXO_USUARIO}{usuario_id}")
+            return
+        except Exception as e:
+            logger.warning("Falha ao desbloquear usuário no Redis (%s). Fallback memória.", e)
+    _memoria_usuarios.discard(usuario_id)
+
+
+def usuario_bloqueado(usuario_id: str) -> bool:
+    """Indica se as sessões do usuário foram encerradas (conta desativada)."""
+    usuario_id = str(usuario_id)
+    client = _get_redis()
+    if client:
+        try:
+            return client.exists(f"{_PREFIXO_USUARIO}{usuario_id}") == 1
+        except Exception as e:
+            logger.warning("Falha ao ler bloqueio no Redis (%s). Fallback memória.", e)
+    return usuario_id in _memoria_usuarios

--- a/backend/application/libs/email_sender.py
+++ b/backend/application/libs/email_sender.py
@@ -1,5 +1,8 @@
 import os
+import time
+import logging
 import smtplib
+import threading
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from pathlib import Path
@@ -7,12 +10,69 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
+logger = logging.getLogger(__name__)
+
 SMTP_HOST = os.getenv("SMTP_HOST", "smtp.gmail.com")
 SMTP_PORT = int(os.getenv("SMTP_PORT", 587))
 SMTP_USER = os.getenv("SMTP_USER")
 SMTP_PASSWORD = os.getenv("SMTP_PASSWORD")
 SMTP_FROM = os.getenv("SMTP_FROM", SMTP_USER)
 FRONTEND_URL = os.getenv("FRONTEND_URL", "http://localhost:3000")
+
+# Tempo máximo (em segundos) de espera por cada operação SMTP, evitando que um
+# servidor lento estoure o limite de 2 minutos para o envio (US-03-RNF1).
+SMTP_TIMEOUT = int(os.getenv("SMTP_TIMEOUT", 30))
+# Número de tentativas de envio antes de desistir.
+SMTP_TENTATIVAS = int(os.getenv("SMTP_TENTATIVAS", 3))
+
+
+def _enviar_mensagem(msg: MIMEMultipart, destinatario: str) -> None:
+    """
+    Envia uma mensagem MIME via SMTP com timeout e novas tentativas.
+
+    Reenvia em caso de falha transitória (até `SMTP_TENTATIVAS`), aplicando um
+    pequeno intervalo entre as tentativas. Levanta a última exceção caso todas
+    as tentativas falhem.
+    """
+    ultimo_erro = None
+
+    for tentativa in range(1, SMTP_TENTATIVAS + 1):
+        try:
+            with smtplib.SMTP(SMTP_HOST, SMTP_PORT, timeout=SMTP_TIMEOUT) as server:
+                server.ehlo()
+                server.starttls()
+                server.ehlo()
+                server.login(SMTP_USER, SMTP_PASSWORD)
+                server.sendmail(SMTP_USER, destinatario, msg.as_string())
+            return
+        except Exception as e:
+            ultimo_erro = e
+            logger.warning(
+                "Falha ao enviar e-mail para %s (tentativa %d/%d): %s",
+                destinatario, tentativa, SMTP_TENTATIVAS, e,
+            )
+            if tentativa < SMTP_TENTATIVAS:
+                time.sleep(2 * tentativa)
+
+    raise ultimo_erro
+
+
+def enviar_email_convite_async(destinatario_email: str, destinatario_nome: str, token: str) -> None:
+    """
+    Dispara o e-mail de convite em uma thread separada.
+
+    Garante que o cadastro do usuário responda imediatamente, enquanto o envio
+    (com timeout e novas tentativas) ocorre em segundo plano dentro da janela de
+    2 minutos exigida pelo requisito (US-03-RNF1). Falhas definitivas são
+    registradas em log.
+    """
+    def _run():
+        try:
+            enviar_email_convite(destinatario_email, destinatario_nome, token)
+        except Exception as e:
+            logger.error("Erro ao enviar e-mail de convite para %s: %s", destinatario_email, e)
+
+    threading.Thread(target=_run, daemon=True).start()
 
 
 def enviar_email_convite(destinatario_email: str, destinatario_nome: str, token: str) -> None:
@@ -155,12 +215,7 @@ def enviar_email_convite(destinatario_email: str, destinatario_nome: str, token:
 
     msg.attach(MIMEText(corpo_html, "html"))
 
-    with smtplib.SMTP(SMTP_HOST, SMTP_PORT) as server:
-        server.ehlo()
-        server.starttls()
-        server.ehlo()
-        server.login(SMTP_USER, SMTP_PASSWORD)
-        server.sendmail(SMTP_USER, destinatario_email, msg.as_string())
+    _enviar_mensagem(msg, destinatario_email)
 
 
 def enviar_email_recuperacao_senha(destinatario_email: str, destinatario_nome: str, token: str) -> None:
@@ -266,9 +321,4 @@ def enviar_email_recuperacao_senha(destinatario_email: str, destinatario_nome: s
 
     msg.attach(MIMEText(corpo_html, "html"))
 
-    with smtplib.SMTP(SMTP_HOST, SMTP_PORT) as server:
-        server.ehlo()
-        server.starttls()
-        server.ehlo()
-        server.login(SMTP_USER, SMTP_PASSWORD)
-        server.sendmail(SMTP_USER, destinatario_email, msg.as_string())
+    _enviar_mensagem(msg, destinatario_email)

--- a/backend/application/libs/email_sender.py
+++ b/backend/application/libs/email_sender.py
@@ -54,7 +54,14 @@ def _enviar_mensagem(msg: MIMEMultipart, destinatario: str) -> None:
             if tentativa < SMTP_TENTATIVAS:
                 time.sleep(2 * tentativa)
 
-    raise ultimo_erro
+    # `ultimo_erro` só é None se o laço nunca executou (SMTP_TENTATIVAS <= 0);
+    # nesse caso levantamos um erro explícito em vez de `raise None` (TypeError).
+    if ultimo_erro is not None:
+        raise ultimo_erro
+    raise RuntimeError(
+        f"Falha ao enviar e-mail para {destinatario}: nenhuma tentativa foi executada "
+        f"(SMTP_TENTATIVAS={SMTP_TENTATIVAS})."
+    )
 
 
 def enviar_email_convite_async(destinatario_email: str, destinatario_nome: str, token: str) -> None:

--- a/backend/application/libs/email_sender.py
+++ b/backend/application/libs/email_sender.py
@@ -219,7 +219,8 @@ def enviar_email_convite(destinatario_email: str, destinatario_nome: str, token:
 
 
 def enviar_email_recuperacao_senha(destinatario_email: str, destinatario_nome: str, token: str) -> None:
-    link = f"{FRONTEND_URL}/alterar-senha?token={token}"
+    # reset=1 sinaliza à tela que é redefinição de senha (exibe a tag "Redefinir senha").
+    link = f"{FRONTEND_URL}/alterar-senha?token={token}&reset=1"
 
     msg = MIMEMultipart("alternative")
     msg["Subject"] = "Redefinição de senha — Tutor"

--- a/backend/application/models/__init__.py
+++ b/backend/application/models/__init__.py
@@ -10,5 +10,5 @@ from .model_arquivo_turma_materia import ArquivoTurmaMateria
 from .model_aluno_turma import AlunoTurma
 from .model_sessao import Sessao
 from .model_llm import LLM
-from .model_usuario import Usuario, RoleEnum 
+from .model_usuario import Usuario, RoleEnum, StatusEnum
 from .model_aluno_turma import AlunoTurma

--- a/backend/application/models/model_usuario.py
+++ b/backend/application/models/model_usuario.py
@@ -6,8 +6,10 @@ class RoleEnum(enum.Enum):
     ADMIN = 1
     PROFESSOR = 2
     ALUNO = 3
-    ATIVO = 4
-    INATIVO = 5
+
+class StatusEnum(enum.Enum):
+    ATIVO = 1
+    INATIVO = 2
 
 class Usuario(db.Model):
     __tablename__ = 'usuario'
@@ -17,8 +19,11 @@ class Usuario(db.Model):
     nome = db.Column(db.String(64), nullable=False)
     email = db.Column(db.String(64), nullable=False, unique=True, index=True)
     senha = db.Column(db.String(256), nullable=False)
+    # role e status usam enums distintos (GAP-02-K) — evita estados inválidos como
+    # status=PROFESSOR. Como native_enum=False armazena o NOME, a separação não
+    # exige migração de dados (os valores gravados continuam 'ATIVO'/'INATIVO').
     role = db.Column(db.Enum(RoleEnum, native_enum=False), nullable=False)
-    status = db.Column(db.Enum(RoleEnum, native_enum=False), nullable=False)
+    status = db.Column(db.Enum(StatusEnum, native_enum=False), nullable=False)
 
     turmas_matriculadas = db.relationship('AlunoTurma', back_populates='aluno', cascade='all, delete-orphan')
     turmas_materias = db.relationship('ProfessorTurmaMateria', back_populates='professor', cascade='all, delete-orphan')

--- a/backend/application/routes/route_admin.py
+++ b/backend/application/routes/route_admin.py
@@ -1,7 +1,7 @@
 """
 Rotas para lidar com admin.
 """
-from flask import Blueprint, jsonify, current_app, request, g
+from flask import Blueprint, jsonify, request, g
 from application.auth.auth_decorators import token_obrigatorio, apenas_admins
 from application.auth.token_denylist import bloquear_usuario, desbloquear_usuario
 import uuid

--- a/backend/application/routes/route_admin.py
+++ b/backend/application/routes/route_admin.py
@@ -394,9 +394,6 @@ def lista_materias():
     
     materia = materia.all()
 
-    if not materia:
-        return jsonify({"Error": "Materia não encontrada"}), 404
-
     return jsonify({
         "success": True,
         "Materias": [m.to_dict() for m in materia],

--- a/backend/application/routes/route_admin.py
+++ b/backend/application/routes/route_admin.py
@@ -55,7 +55,8 @@ def listar_todos_usuarios():
             matricula = request.args.get('matricula'),
             role = request.args.get('role'),
             status = request.args.get('status'),
-            turma =request.args.get('turma')
+            turma =request.args.get('turma'),
+            busca = request.args.get('busca')
         )
 
         if limit:

--- a/backend/application/routes/route_admin.py
+++ b/backend/application/routes/route_admin.py
@@ -11,9 +11,9 @@ from application.services.service_usuario import (criar_usuario, buscar_aluno, d
 import secrets
 from application.config.database import db
 from datetime import datetime
-from application.libs.email_sender import enviar_email_convite
+from application.libs.email_sender import enviar_email_convite_async
 from flask import make_response
-from application.auth.jwt_handler import gerar_token
+from application.auth.jwt_handler import gerar_token, definir_cookie_sessao
 from application.services.service_usuario import definir_senha_primeiro_acesso, _validar_forca_senha
 from application.services.service_materia import getAllSubjects, createSubject, updateSubject, deleteSubject, buscar_materia_por_id
 
@@ -130,10 +130,9 @@ def gerar_aluno():
     usuario_dict, token = criar_usuario(matricula, nome, email, via_google)
 
     if not via_google and token:
-        try:
-            enviar_email_convite(email, nome, token)
-        except Exception as e:
-            current_app.logger.error(f"Erro ao enviar e-mail de convite para {email}: {e}")
+        # Envio assíncrono (não bloqueia a resposta do cadastro) com timeout e
+        # novas tentativas dentro da janela de 2 minutos exigida (US-03-RNF1).
+        enviar_email_convite_async(email, nome, token)
 
     return jsonify(usuario_dict), 201
 
@@ -352,15 +351,7 @@ def recriar_senha():
         "redirect": f"/painel/{role_slug}"
     }), 200)
 
-    response.set_cookie(
-        "token",
-        token_jwt,
-        httponly=True,
-        secure=False,
-        samesite="Lax",
-        max_age=60 * 60,
-        path="/"
-    )
+    definir_cookie_sessao(response, token_jwt)
 
     return response
 

--- a/backend/application/routes/route_admin.py
+++ b/backend/application/routes/route_admin.py
@@ -1,8 +1,9 @@
 """
 Rotas para lidar com admin.
 """
-from flask import Blueprint, jsonify, current_app, request
+from flask import Blueprint, jsonify, current_app, request, g
 from application.auth.auth_decorators import token_obrigatorio, apenas_admins
+from application.auth.token_denylist import bloquear_usuario, desbloquear_usuario
 import uuid
 from application.models.model_usuario import RoleEnum, Usuario
 from application.models.model_materia import Materia
@@ -118,6 +119,12 @@ def gerar_aluno():
     email = dados.get('email')
     via_google = dados.get('via_google', False)
 
+    # Papel atribuído de forma atômica na criação (GAP-02-I). Default: ALUNO.
+    role_str = (dados.get('role') or 'ALUNO').upper()
+    if role_str not in ('ADMIN', 'PROFESSOR', 'ALUNO'):
+        role_str = 'ALUNO'
+    role_enum = RoleEnum[role_str]
+
     if not matricula or not nome or not email:
         return jsonify({"error": "Parâmetros 'matricula', 'nome' e 'email' são obrigatórios"}), 400
 
@@ -135,7 +142,7 @@ def gerar_aluno():
     if erros:
         return jsonify({"error": " ".join(erros.values()), "campos": erros}), 409
 
-    usuario_dict, token = criar_usuario(matricula, nome, email, via_google)
+    usuario_dict, token = criar_usuario(matricula, nome, email, via_google, role=role_enum)
 
     if not via_google and token:
         # Envio assíncrono (não bloqueia a resposta do cadastro) com timeout e
@@ -165,10 +172,17 @@ def deletar_usuario(id):
     }
     ```
     """
+    # GAP-02-C: o admin não pode desativar a própria conta.
+    if str(g.usuario_id) == str(id):
+        return jsonify({"error": "Você não pode desativar a própria conta."}), 403
+
     aluno = desativar_aluno(id)
 
     if not aluno:
         return jsonify({"error": "Usuario não encontrado"}), 404
+
+    # GAP-02-B: encerra as sessões ativas do usuário desativado.
+    bloquear_usuario(id)
 
     return jsonify({
         "Usuario:": aluno.nome,
@@ -240,7 +254,7 @@ def atualizar_aluno_por_id(id):
 
     if not email.endswith("@iesb.edu.br"):
         return jsonify({"error": "Email deve ser institucional (@iesb.edu.br)"}), 400
-    
+
     if status not in ["ATIVO", "INATIVO"]:
         return jsonify({"error": "Status deve ser ATIVO ou INATIVO"}), 400
 
@@ -248,8 +262,16 @@ def atualizar_aluno_por_id(id):
 
     if not aluno_existente:
         return jsonify({"error: Usuario não encontrado"}), 404
-    
-    aluno_novo = alterar_aluno_por_id(id, matricula, nome, email, status, role)
+
+    # GAP-02-F: e-mail já usado por OUTRO usuário → 409 (em vez de IntegrityError/500).
+    if Usuario.query.filter(Usuario.email == email, Usuario.id != id).first():
+        return jsonify({
+            "error": "Este e-mail já está em uso por outro usuário.",
+            "campos": {"email": "Este e-mail já está em uso por outro usuário."},
+        }), 409
+
+    # GAP-02-E: matrícula é imutável após o cadastro — preserva a existente.
+    aluno_novo = alterar_aluno_por_id(id, aluno_existente['matricula'], nome, email, status, role)
 
     return jsonify(aluno_novo), 200
 
@@ -288,6 +310,9 @@ def reativar_usuario(id):
         return jsonify({"error: Usuario não encontrado"}), 404
     
     aluno = reativar_aluno(id, status)
+
+    # Reabilita as sessões do usuário reativado (contrapartida do GAP-02-B).
+    desbloquear_usuario(id)
 
     return jsonify({
         "Usuario:": aluno["nome"],

--- a/backend/application/routes/route_admin.py
+++ b/backend/application/routes/route_admin.py
@@ -447,7 +447,7 @@ def gerar_materia():
 
 
     if not codigo or not nome:
-        return jsonify({"error": "Parâmetros 'matricula', 'nome' e 'email' são obrigatórios"}), 400
+        return jsonify({"error": "Parâmetros 'codigo' e 'nome' são obrigatórios"}), 400
 
 
     existente = Materia.query.filter(
@@ -483,8 +483,10 @@ def atualizar_materia(id):
 
     if not materia_existente:
         return jsonify({"Error": "Materia não econtrada"}), 404
-    
-    materia_nova = updateSubject(id,nome,codigo,status)
+
+    # G5: o código é imutável após o cadastro — preserva o existente, ignorando
+    # qualquer valor enviado no corpo (bloqueio já existia só no frontend).
+    materia_nova = updateSubject(id, nome, materia_existente['codigo'], status)
 
     return jsonify(materia_nova), 200
 

--- a/backend/application/routes/route_admin.py
+++ b/backend/application/routes/route_admin.py
@@ -20,6 +20,8 @@ from application.services.service_materia import getAllSubjects, createSubject, 
 admin_bp = Blueprint('admin', __name__)
 
 @admin_bp.route('/usuarios/all', methods=['GET'])
+@token_obrigatorio
+@apenas_admins
 def listar_todos_usuarios():
     """
     Endpoint para listar usuarios
@@ -85,6 +87,8 @@ def listar_todos_usuarios():
 
     
 @admin_bp.route('/usuarios/criar', methods=['POST'])
+@token_obrigatorio
+@apenas_admins
 def gerar_aluno():
     """
     Endpoint para criar um usuário e disparar e-mail de convite.
@@ -120,12 +124,16 @@ def gerar_aluno():
     if not email.endswith("@iesb.edu.br"):
         return jsonify({"error": "Email deve ser institucional (@iesb.edu.br)"}), 400
 
-    existente = Usuario.query.filter(
-        (Usuario.matricula == matricula) | (Usuario.email == email)
-    ).first()
+    # Checagem separada por campo, com as mensagens específicas do épico/Figma
+    # (US-07-RV2/US-08-RV2). `campos` permite ao front marcar o campo certo.
+    erros = {}
+    if Usuario.query.filter(Usuario.matricula == matricula).first():
+        erros["matricula"] = "Esta matrícula já está em uso por outro usuário."
+    if Usuario.query.filter(Usuario.email == email).first():
+        erros["email"] = "Este e-mail já está em uso por outro usuário."
 
-    if existente:
-        return jsonify({"error": "Email ou matrícula já cadastrados."}), 409
+    if erros:
+        return jsonify({"error": " ".join(erros.values()), "campos": erros}), 409
 
     usuario_dict, token = criar_usuario(matricula, nome, email, via_google)
 
@@ -138,6 +146,8 @@ def gerar_aluno():
 
 
 @admin_bp.route("/usuarios/delete/<uuid:id>", methods=['DELETE'])
+@token_obrigatorio
+@apenas_admins
 def deletar_usuario(id):
     """
     Endpoint para deletar(Inativar) usuario por id
@@ -170,6 +180,8 @@ def deletar_usuario(id):
 
 
 @admin_bp.route("/usuarios/<uuid:id>", methods=['GET'])
+@token_obrigatorio
+@apenas_admins
 def buscar_alunos_por_id(id):
     """
     Endpoint para buscar usuario por id
@@ -195,6 +207,8 @@ def buscar_alunos_por_id(id):
 
 
 @admin_bp.route("/usuarios/<uuid:id>", methods=['PUT'])
+@token_obrigatorio
+@apenas_admins
 def atualizar_aluno_por_id(id):
     """
     Endpoint para atualizar usuario por id
@@ -242,6 +256,8 @@ def atualizar_aluno_por_id(id):
 
 
 @admin_bp.route("/usuarios/<uuid:id>/reativar", methods=['PATCH'])
+@token_obrigatorio
+@apenas_admins
 def reativar_usuario(id):
     """
     Endpoint para reativar usuario por id

--- a/backend/application/routes/route_auth.py
+++ b/backend/application/routes/route_auth.py
@@ -4,7 +4,7 @@ Rotas de autenticação — primeiro acesso e redefinição de senha.
 import uuid
 from flask import Blueprint, jsonify, request, current_app, make_response
 from application.config.database import db
-from application.models.model_usuario import Usuario, RoleEnum, StatusEnum
+from application.models.model_usuario import Usuario, StatusEnum
 from application.models.model_token_convite import TokenConvite
 from application.services.service_usuario import (validar_token_convite, definir_senha_primeiro_acesso)
 from application.libs.email_sender import enviar_email_recuperacao_senha

--- a/backend/application/routes/route_auth.py
+++ b/backend/application/routes/route_auth.py
@@ -2,12 +2,13 @@
 Rotas de autenticação — primeiro acesso e redefinição de senha.
 """
 import uuid
-from flask import Blueprint, jsonify, request, current_app
+from flask import Blueprint, jsonify, request, current_app, make_response
 from application.config.database import db
 from application.models.model_usuario import Usuario, RoleEnum
 from application.models.model_token_convite import TokenConvite
 from application.services.service_usuario import (validar_token_convite, definir_senha_primeiro_acesso)
 from application.libs.email_sender import enviar_email_recuperacao_senha
+from application.auth.jwt_handler import gerar_token, definir_cookie_sessao
 import re
 
 REGEX_SENHA = re.compile(r'^(?=.*[a-z])(?=.*[A-Z])(?=.*\d).{8,}$')
@@ -70,14 +71,15 @@ def definir_senha():
     - Após salvar o hash da senha, `TokenConvite.used` é marcado como True.
 
     Retorna:
-    - `200 OK` com dados básicos do usuário após sucesso.
+    - `200 OK` com os dados do usuário e cookie de sessão (JWT) — o usuário já fica
+      autenticado e o front redireciona à home do perfil (US-03-RN3).
     - `400 Bad Request` se parâmetros ausentes.
     - `410 Gone` se token inválido ou já utilizado.
     - `422 Unprocessable Entity` se as senhas não conferem ou não atendem aos requisitos.
  
 ```json
-    // 200 OK
-    { "mensagem": "Senha criada com sucesso." }
+    // 200 OK  (+ Set-Cookie: token=<jwt>)
+    { "mensagem": "Senha criada com sucesso.", "usuario": { "id": "...", "role": "ALUNO" } }
  
     // 400 Bad Request
     { "error": "Parâmetros 'token' e 'senha' são obrigatórios" }
@@ -114,14 +116,22 @@ def definir_senha():
         }), 410
  
     usuario = definir_senha_primeiro_acesso(token, senha)
- 
+
     if usuario is None:
         return jsonify({
             "error": "A senha não atende aos requisitos mínimos.",
             "requisitos": "Mínimo 8 caracteres, uma letra maiúscula, uma minúscula e um número."
         }), 422
- 
-    return jsonify({"mensagem": "Senha criada com sucesso."}), 200
+
+    # US-03-RN3: token já foi invalidado no service; inicia a sessão (emite JWT)
+    # e devolve o usuário para o front redirecionar à home do perfil.
+    token_jwt = gerar_token(usuario['id'], usuario['role'])
+    response = make_response(jsonify({
+        "mensagem": "Senha criada com sucesso.",
+        "usuario": usuario,
+    }), 200)
+    definir_cookie_sessao(response, token_jwt)
+    return response
 
 
 @auth_bp.route('/forgot-password', methods=['POST'])

--- a/backend/application/routes/route_auth.py
+++ b/backend/application/routes/route_auth.py
@@ -60,18 +60,20 @@ def definir_senha():
     Espera receber (JSON):
     - `token`: str — token UUID do convite
     - `senha`: str — nova senha escolhida pelo usuário
- 
+    - `confirmacao`: str — repetição da nova senha para confirmação
+
     Regras:
     - Token precisa existir e não ter sido utilizado (campo `used=False`).
+    - `senha` e `confirmacao` devem ser idênticas.
     - Senha validada pelo `_validar_forca_senha` do próprio service:
       8+ chars, maiúscula, minúscula e número.
     - Após salvar o hash da senha, `TokenConvite.used` é marcado como True.
- 
+
     Retorna:
     - `200 OK` com dados básicos do usuário após sucesso.
     - `400 Bad Request` se parâmetros ausentes.
     - `410 Gone` se token inválido ou já utilizado.
-    - `422 Unprocessable Entity` se a senha não atende aos requisitos.
+    - `422 Unprocessable Entity` se as senhas não conferem ou não atendem aos requisitos.
  
 ```json
     // 200 OK
@@ -96,10 +98,14 @@ def definir_senha():
     data = request.get_json(silent=True) or {}
     token = data.get('token', '').strip()
     senha = data.get('senha', '')
- 
+    confirmacao = data.get('confirmacao', '')
+
     if not token or not senha:
         return jsonify({"error": "Parâmetros 'token' e 'senha' são obrigatórios"}), 400
- 
+
+    if senha != confirmacao:
+        return jsonify({"error": "As senhas não conferem. Por favor, digite novamente."}), 422
+
     _, status_token = validar_token_convite(token)
     if status_token == 'utilizado_ou_inexistente':
         return jsonify({

--- a/backend/application/routes/route_auth.py
+++ b/backend/application/routes/route_auth.py
@@ -4,7 +4,7 @@ Rotas de autenticação — primeiro acesso e redefinição de senha.
 import uuid
 from flask import Blueprint, jsonify, request, current_app, make_response
 from application.config.database import db
-from application.models.model_usuario import Usuario, RoleEnum
+from application.models.model_usuario import Usuario, RoleEnum, StatusEnum
 from application.models.model_token_convite import TokenConvite
 from application.services.service_usuario import (validar_token_convite, definir_senha_primeiro_acesso)
 from application.libs.email_sender import enviar_email_recuperacao_senha
@@ -144,7 +144,7 @@ def recuperar_senha():
 
     usuario = Usuario.query.filter_by(email=email).first()
 
-    if usuario and usuario.status == RoleEnum.ATIVO:
+    if usuario and usuario.status == StatusEnum.ATIVO:
         TokenConvite.query.filter_by(usuario_id=usuario.id, used=False).update({'used': True})
         db.session.commit()
 

--- a/backend/application/routes/route_auth.py
+++ b/backend/application/routes/route_auth.py
@@ -105,7 +105,9 @@ def definir_senha():
     if not token or not senha:
         return jsonify({"error": "Parâmetros 'token' e 'senha' são obrigatórios"}), 400
 
-    if senha != confirmacao:
+    # Valida a confirmação somente quando ela é enviada — evita quebrar clientes
+    # que não mandam o campo (a força da senha continua sendo verificada adiante).
+    if confirmacao and senha != confirmacao:
         return jsonify({"error": "As senhas não conferem. Por favor, digite novamente."}), 422
 
     _, status_token = validar_token_convite(token)

--- a/backend/application/routes/route_usuarios.py
+++ b/backend/application/routes/route_usuarios.py
@@ -6,7 +6,7 @@ from application.config.database import db
 from flask import Blueprint, request, jsonify, g
 from google.oauth2 import id_token
 from google.auth.transport import requests as grequests
-from application.auth.jwt_handler import gerar_token
+from application.auth.jwt_handler import gerar_token, definir_cookie_sessao
 from application.auth.auth_decorators import token_obrigatorio, extrair_token, invalidar_token, apenas_admins
 from application.services.service_usuario import buscar_aluno, logar_aluno, buscar_professor
 from application.models import Usuario
@@ -120,7 +120,7 @@ def login_google():
 
         if not aluno:
             return jsonify({
-                "error": "Usuário não cadastrado. Entre em contato com a instituição."
+                "error": "Sua conta Google não está vinculada a nenhum usuário nesta plataforma. Entre em contato com o administrador."
             }), 404
 
         if aluno.status.name != 'ATIVO':
@@ -132,15 +132,7 @@ def login_google():
             "aluno": aluno.to_dict()
         }))
 
-        response.set_cookie(
-            "token",
-            token_jwt,
-            httponly=True,
-            secure=False,
-            samesite="Lax",
-            max_age=60 * 60,
-            path="/"
-        )
+        definir_cookie_sessao(response, token_jwt)
 
         return response
 
@@ -195,15 +187,7 @@ def login_aluno():
         "aluno": aluno
     }))
 
-    response.set_cookie(
-        "token",
-        token,
-        httponly=True,
-        secure=False,
-        samesite="Lax",
-        max_age=60 * 60,
-        path="/"
-    )
+    definir_cookie_sessao(response, token)
 
     return response
 
@@ -243,6 +227,9 @@ def encerrarr_sessao():
 
     invalidar_token(token)
 
+    # Impede que o after_request reabra a sessão com um token renovado.
+    g.refresh_token = None
+
     response = jsonify({
         "mensagem": "Sessão encerrada com sucesso"
     })
@@ -250,6 +237,18 @@ def encerrarr_sessao():
     response.delete_cookie("token")
 
     return response, 200
+
+
+@usuarios_bp.route('/sessao/touch', methods=['POST'])
+@token_obrigatorio
+def touch_sessao():
+    """
+    Renova a sessão por atividade (sliding expiration). Não retorna dados; a
+    renovação do cookie é feita pelo `after_request` via `g.refresh_token`.
+    Usado pelo chat para que o envio de mensagens (via socket) também mantenha
+    a sessão HTTP viva — já que um WebSocket aberto não pode reescrever o cookie.
+    """
+    return jsonify({"ok": True}), 200
 
 
 @usuarios_bp.route('/professors', methods=['GET'])

--- a/backend/application/routes/route_usuarios.py
+++ b/backend/application/routes/route_usuarios.py
@@ -7,7 +7,8 @@ from flask import Blueprint, request, jsonify, g
 from google.oauth2 import id_token
 from google.auth.transport import requests as grequests
 from application.auth.jwt_handler import gerar_token, definir_cookie_sessao
-from application.auth.auth_decorators import token_obrigatorio, extrair_token, invalidar_token, apenas_admins
+from application.auth.auth_decorators import token_obrigatorio, extrair_token, apenas_admins
+from application.auth.token_denylist import invalidar_token
 from application.services.service_usuario import buscar_aluno, logar_aluno, buscar_professor
 from application.models import Usuario
 

--- a/backend/application/routes/route_usuarios.py
+++ b/backend/application/routes/route_usuarios.py
@@ -278,9 +278,6 @@ def buscarProfessores():
 
     professor = professor.all()
 
-    if not professor:
-        return jsonify({"Error": "Professor não encontrado"}), 404
-    
     return jsonify({
         "success": True,
         "Professores": [p.to_dict() for p in professor],

--- a/backend/application/services/service_arquivo.py
+++ b/backend/application/services/service_arquivo.py
@@ -80,6 +80,7 @@ def salvar_documento_vetor(documento_id: uuid.UUID, titulo: str, professor_id: u
     collection.add(
         ids=[str(documento_id)],
         metadatas=[{
+            "arquivo_id": str(documento_id),
             "titulo": titulo,
             "professor_id": str(professor_id),
             "vinculos": formatted_vinculos,

--- a/backend/application/services/service_usuario.py
+++ b/backend/application/services/service_usuario.py
@@ -125,22 +125,42 @@ def reativar_aluno(id: uuid.UUID, status_novo: str = RoleEnum.ATIVO):
     return aluno.to_dict()
 
 
-def buscar_alunos_por_filtro(nome: str, matricula: str, turma: str, role: str, status: str):
-    """Busca avançada de alunos com suporte a joins de turma."""
+def buscar_alunos_por_filtro(nome: str = None, matricula: str = None, turma: str = None,
+                             role: str = None, status: str = None, busca: str = None):
+    """
+    Busca avançada de usuários com suporte a join de turma e a uma busca única
+    (`busca`) que casa por nome, matrícula OU e-mail (US-08-RNF2). `role`/`status`
+    aceitam string (nome do RoleEnum) e são convertidos com segurança.
+    """
     query = Usuario.query
 
     if turma:
         query = query.join(AlunoTurma).filter(AlunoTurma.turma.ilike(f"%{turma}%"))
 
+    if busca:
+        termo = f"%{busca}%"
+        query = query.filter(db.or_(
+            Usuario.nome.ilike(termo),
+            Usuario.matricula.ilike(termo),
+            Usuario.email.ilike(termo),
+        ))
+
     if nome:
         query = query.filter(Usuario.nome.ilike(f"%{nome}%"))
     if matricula:
         query = query.filter(Usuario.matricula.ilike(f"%{matricula}%"))
+
     if role:
-        query = query.filter(Usuario.role == role)
+        if isinstance(role, str):
+            role = RoleEnum.__members__.get(role)
+        if role:
+            query = query.filter(Usuario.role == role)
     if status:
-        query = query.filter(Usuario.status == status)
-    
+        if isinstance(status, str):
+            status = RoleEnum.__members__.get(status)
+        if status:
+            query = query.filter(Usuario.status == status)
+
     return query.order_by(Usuario.nome.asc())
 
 

--- a/backend/application/services/service_usuario.py
+++ b/backend/application/services/service_usuario.py
@@ -3,7 +3,7 @@ import re
 import secrets
 from werkzeug.security import generate_password_hash, check_password_hash
 
-from application.models.model_usuario import Usuario, RoleEnum
+from application.models.model_usuario import Usuario, RoleEnum, StatusEnum
 from application.models.model_aluno_turma import AlunoTurma
 from application.models.model_token_convite import TokenConvite
 from application.config.database import db
@@ -29,7 +29,7 @@ def criar_usuario(
         email=email,
         senha=senha_hash,
         role=role,
-        status=RoleEnum.ATIVO
+        status=StatusEnum.ATIVO
     )
     db.session.add(usuario)
     db.session.flush()
@@ -93,7 +93,7 @@ def desativar_aluno(aluno_id: uuid.UUID):
     if not aluno:
         return None
     
-    aluno.status = RoleEnum.INATIVO
+    aluno.status = StatusEnum.INATIVO
     db.session.commit()
     return aluno
 
@@ -114,7 +114,7 @@ def alterar_aluno_por_id(id: uuid.UUID, matricula_nova: str, nome_novo: str, ema
     return aluno.to_dict()
 
 
-def reativar_aluno(id: uuid.UUID, status_novo: str = RoleEnum.ATIVO):
+def reativar_aluno(id: uuid.UUID, status_novo: str = StatusEnum.ATIVO):
     """Reativa um usuário no sistema."""
     aluno = Usuario.query.get(id)
     if not aluno:
@@ -157,7 +157,7 @@ def buscar_alunos_por_filtro(nome: str = None, matricula: str = None, turma: str
             query = query.filter(Usuario.role == role)
     if status:
         if isinstance(status, str):
-            status = RoleEnum.__members__.get(status)
+            status = StatusEnum.__members__.get(status)
         if status:
             query = query.filter(Usuario.status == status)
 

--- a/backend/application/services/service_usuario.py
+++ b/backend/application/services/service_usuario.py
@@ -12,10 +12,12 @@ def criar_usuario(
     matricula: str,
     nome: str,
     email: str,
-    via_google: bool = False
+    via_google: bool = False,
+    role: RoleEnum = RoleEnum.ALUNO
 ) -> tuple[dict, str | None]:
     """
     Cria um novo usuário no banco com senha aleatória.
+    O papel é atribuído de forma atômica na criação (GAP-02-I) — por padrão ALUNO.
     Gera um token de convite se não for via Google.
     """
     senha_aleatoria = secrets.token_hex(16)
@@ -26,8 +28,8 @@ def criar_usuario(
         nome=nome,
         email=email,
         senha=senha_hash,
-        role=RoleEnum.ALUNO,      
-        status=RoleEnum.ATIVO     
+        role=role,
+        status=RoleEnum.ATIVO
     )
     db.session.add(usuario)
     db.session.flush()

--- a/backend/application/socket/Impl/busca_semantica.py
+++ b/backend/application/socket/Impl/busca_semantica.py
@@ -54,6 +54,6 @@ async def busca_semantica(materia_id:str,query:str) -> List[str]:
 
     if not arquivos_ids: return ""
 
-    chunks = await asyncio.to_thread(buscar_no_vector_db(query,arquivos_ids))
+    chunks = await asyncio.to_thread(buscar_no_vector_db, query, arquivos_ids)
 
     return formatar_para_rag(chunks)

--- a/backend/application/socket/event_handler.py
+++ b/backend/application/socket/event_handler.py
@@ -9,6 +9,9 @@ from flask import request, current_app
 
 from application.socket.socket_instance import socketio
 
+from application.auth.jwt_handler import validar_token
+from application.auth.auth_decorators import extrair_token, token_invalido
+
 from application.socket.Impl.registrar_chat import registrar_chat
 from application.socket.Impl.registrar_mensagem import registrar_mensagem
 from application.socket.Impl.validacao_emit import validacao_emit
@@ -16,13 +19,51 @@ from application.socket.Impl.disparar_emit import disparar_emit
 from application.socket.Impl.busca_semantica import busca_semantica
 from application.socket.Impl.prompt_builder import build_prompt
 
+# Identidade autenticada por conexão (sid -> usuario_id), definida no handshake.
+SOCKET_USUARIOS = {}
+
+
+def _autenticar_handshake():
+    """Valida o JWT do cookie do handshake. Retorna o usuario_id ou None."""
+    token = extrair_token()
+    if not token or token_invalido(token):
+        return None
+    payload = validar_token(token)
+    if not payload:
+        return None
+    return str(payload.get("user_id"))
+
+
 @socketio.on("connect")
 def handle_connect():
+    # Autentica pelo cookie enviado no handshake; rejeita conexões sem sessão
+    # válida (fecha GAP-06-F: o socket deixa de confiar no id vindo do cliente).
+    usuario_id = _autenticar_handshake()
+    if not usuario_id:
+        return False
+    SOCKET_USUARIOS[request.sid] = usuario_id
     emit("connection-confirmation", {"data": "Conexão estabelecida"})
+
+
+@socketio.on("disconnect")
+def handle_disconnect():
+    SOCKET_USUARIOS.pop(request.sid, None)
+
 
 @socketio.on('mensagem_inicial')
 def maestro(data):
     sid = request.sid
+
+    usuario_id = SOCKET_USUARIOS.get(sid)
+    if not usuario_id:
+        return disparar_emit(
+            socketio, "sessao_expirada",
+            {"erro": "Sessão não autenticada. Faça login novamente."}, room=sid
+        )
+
+    # Usa a identidade autenticada no handshake, ignorando o id_usuario do payload.
+    data = {**data, "id_usuario": usuario_id}
+
     socketio.start_background_task(
         processar_mensagem,
         data,

--- a/backend/application/socket/socket_instance.py
+++ b/backend/application/socket/socket_instance.py
@@ -1,3 +1,8 @@
+import os
 from flask_socketio import SocketIO
 
-socketio = SocketIO(cors_allowed_origins="*", async_mode="gevent")
+# Origem específica (não "*") é obrigatória para que o handshake aceite o cookie
+# de sessão com credenciais. Configurável via FRONTEND_URL.
+FRONTEND_URL = os.getenv("FRONTEND_URL", "http://localhost:3000")
+
+socketio = SocketIO(cors_allowed_origins=[FRONTEND_URL], async_mode="gevent")

--- a/backend/application/tests/auth/test_auth_decorators.py
+++ b/backend/application/tests/auth/test_auth_decorators.py
@@ -1,0 +1,111 @@
+"""
+Testes unitários dos decoradores de autenticação/autorização.
+
+Usam um app Flask mínimo apenas para fornecer contexto de requisição (`request`,
+`g`, `jsonify`); as dependências de token são mockadas no namespace do módulo.
+"""
+import sys
+from unittest.mock import MagicMock, patch
+
+sys.modules.setdefault("chromadb", MagicMock())
+sys.modules.setdefault("ollama", MagicMock())
+sys.modules.setdefault("application.config.vector_database", MagicMock())
+
+import pytest
+from flask import Flask, g
+
+import application.auth.auth_decorators as ad
+
+flask_app = Flask(__name__)
+
+
+def _eco():
+    """View trivial protegida pelos decoradores."""
+    return "ok"
+
+
+# ---------------------------------------------------------------------------
+# token_obrigatorio
+# ---------------------------------------------------------------------------
+
+def test_token_obrigatorio_sem_token_retorna_401():
+    protegida = ad.token_obrigatorio(_eco)
+    with flask_app.test_request_context():
+        _, status = protegida()
+    assert status == 401
+
+
+def test_token_obrigatorio_token_na_denylist_retorna_401():
+    protegida = ad.token_obrigatorio(_eco)
+    with flask_app.test_request_context(headers={"Authorization": "Bearer x"}):
+        with patch.object(ad, "token_invalido", return_value=True):
+            _, status = protegida()
+    assert status == 401
+
+
+def test_token_obrigatorio_payload_invalido_retorna_401():
+    protegida = ad.token_obrigatorio(_eco)
+    with flask_app.test_request_context(headers={"Authorization": "Bearer x"}):
+        with patch.object(ad, "token_invalido", return_value=False), \
+             patch.object(ad, "validar_token", return_value=None):
+            _, status = protegida()
+    assert status == 401
+
+
+def test_token_obrigatorio_usuario_bloqueado_retorna_401():
+    # Cobre o encerramento de sessão de conta desativada (GAP-02-B).
+    protegida = ad.token_obrigatorio(_eco)
+    with flask_app.test_request_context(headers={"Authorization": "Bearer x"}):
+        with patch.object(ad, "token_invalido", return_value=False), \
+             patch.object(ad, "validar_token", return_value={"user_id": "u1", "role": "ALUNO"}), \
+             patch.object(ad, "usuario_bloqueado", return_value=True):
+            resp, status = protegida()
+    assert status == 401
+
+
+def test_token_obrigatorio_sucesso_chama_view_e_agenda_refresh():
+    protegida = ad.token_obrigatorio(_eco)
+    with flask_app.test_request_context(headers={"Authorization": "Bearer x"}):
+        with patch.object(ad, "token_invalido", return_value=False), \
+             patch.object(ad, "validar_token", return_value={"user_id": "u1", "role": "ADMIN"}), \
+             patch.object(ad, "usuario_bloqueado", return_value=False), \
+             patch.object(ad, "gerar_token", return_value="novo-token"):
+            resultado = protegida()
+            assert resultado == "ok"
+            assert g.usuario_id == "u1"
+            assert g.refresh_token == "novo-token"
+
+
+def test_extrair_token_do_cookie():
+    with flask_app.test_request_context():
+        # sem header → cai no cookie
+        with patch.object(ad.request, "cookies", {"token": "do-cookie"}):
+            assert ad.extrair_token() == "do-cookie"
+
+
+# ---------------------------------------------------------------------------
+# Decoradores de papel
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("decorador,papel_ok", [
+    (lambda f: ad.apenas_admins(f), "ADMIN"),
+    (lambda f: ad.apenas_professores(f), "PROFESSOR"),
+    (lambda f: ad.apenas_alunos(f), "ALUNO"),
+])
+def test_decoradores_de_papel_negam_sem_role(decorador, papel_ok):
+    protegida = decorador(_eco)
+    with flask_app.test_request_context():
+        _, status = protegida()   # g.usuario_role ausente
+    assert status == 403
+
+
+@pytest.mark.parametrize("decorador,papel_ok", [
+    (lambda f: ad.apenas_admins(f), "ADMIN"),
+    (lambda f: ad.apenas_professores(f), "PROFESSOR"),
+    (lambda f: ad.apenas_alunos(f), "ALUNO"),
+])
+def test_decoradores_de_papel_permitem_role_correto(decorador, papel_ok):
+    protegida = decorador(_eco)
+    with flask_app.test_request_context():
+        g.usuario_role = papel_ok
+        assert protegida() == "ok"

--- a/backend/application/tests/auth/test_service_usuario.py
+++ b/backend/application/tests/auth/test_service_usuario.py
@@ -1,0 +1,209 @@
+"""
+Testes unitários do service de usuários.
+
+DB mockado (sem Postgres): exercitam a lógica de filtros/conversões e os fluxos
+de ativação/desativação/alteração sem tocar em banco real.
+"""
+import sys
+from unittest.mock import MagicMock, patch
+
+sys.modules.setdefault("chromadb", MagicMock())
+sys.modules.setdefault("ollama", MagicMock())
+sys.modules.setdefault("application.config.vector_database", MagicMock())
+
+import pytest
+from application.models.model_usuario import RoleEnum, StatusEnum
+import application.services.service_usuario as svc
+
+
+# ---------------------------------------------------------------------------
+# buscar_alunos_por_filtro — busca única, join de turma e conversão de enums
+# ---------------------------------------------------------------------------
+
+@patch("application.services.service_usuario.AlunoTurma")
+@patch("application.services.service_usuario.db")
+@patch("application.services.service_usuario.Usuario")
+def test_buscar_alunos_por_filtro_aplica_todos_os_filtros(mock_usuario, mock_db, mock_aluno_turma):
+    q = MagicMock()
+    mock_usuario.query = q
+    q.join.return_value = q
+    q.filter.return_value = q
+    q.order_by.return_value = "QUERY_FINAL"
+
+    resultado = svc.buscar_alunos_por_filtro(
+        nome="ana", matricula="2024", turma="T1",
+        role="ALUNO", status="ATIVO", busca="maria",
+    )
+
+    assert resultado == "QUERY_FINAL"
+    q.join.assert_called()          # filtro de turma
+    assert q.filter.called          # busca única + nome + matricula + role + status
+    q.order_by.assert_called_once()
+
+
+@patch("application.services.service_usuario.db")
+@patch("application.services.service_usuario.Usuario")
+def test_buscar_alunos_por_filtro_role_status_invalidos_sao_ignorados(mock_usuario, mock_db):
+    q = MagicMock()
+    mock_usuario.query = q
+    q.filter.return_value = q
+    q.order_by.return_value = q
+    # role/status que não existem no enum não devem gerar filtro nem quebrar
+    svc.buscar_alunos_por_filtro(role="INEXISTENTE", status="NAO_EXISTE")
+    q.order_by.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# desativar / reativar / alterar
+# ---------------------------------------------------------------------------
+
+@patch("application.services.service_usuario.db")
+@patch("application.services.service_usuario.Usuario")
+def test_desativar_aluno_define_inativo_e_commita(mock_usuario, mock_db):
+    aluno = MagicMock()
+    mock_usuario.query.get.return_value = aluno
+    resultado = svc.desativar_aluno("id-1")
+    assert aluno.status == StatusEnum.INATIVO
+    mock_db.session.commit.assert_called_once()
+    assert resultado is aluno
+
+
+@patch("application.services.service_usuario.Usuario")
+def test_desativar_aluno_inexistente_retorna_none(mock_usuario):
+    mock_usuario.query.get.return_value = None
+    assert svc.desativar_aluno("id-x") is None
+
+
+@patch("application.services.service_usuario.db")
+@patch("application.services.service_usuario.Usuario")
+def test_reativar_aluno(mock_usuario, mock_db):
+    aluno = MagicMock()
+    mock_usuario.query.get.return_value = aluno
+    svc.reativar_aluno("id-1")
+    assert aluno.status == StatusEnum.ATIVO
+    mock_db.session.commit.assert_called_once()
+
+
+@patch("application.services.service_usuario.Usuario")
+def test_reativar_aluno_inexistente_retorna_none(mock_usuario):
+    mock_usuario.query.get.return_value = None
+    assert svc.reativar_aluno("id-x") is None
+
+
+@patch("application.services.service_usuario.db")
+@patch("application.services.service_usuario.Usuario")
+def test_alterar_aluno_por_id_atualiza_campos(mock_usuario, mock_db):
+    aluno = MagicMock()
+    mock_usuario.query.get.return_value = aluno
+    svc.alterar_aluno_por_id("id-1", "2025", "Novo Nome", "n@iesb.edu.br", "ATIVO", "PROFESSOR")
+    assert aluno.matricula == "2025"
+    assert aluno.nome == "Novo Nome"
+    mock_db.session.commit.assert_called_once()
+
+
+@patch("application.services.service_usuario.Usuario")
+def test_alterar_aluno_por_id_inexistente_retorna_none(mock_usuario):
+    mock_usuario.query.get.return_value = None
+    assert svc.alterar_aluno_por_id("x", "a", "b", "c", "d", "e") is None
+
+
+# ---------------------------------------------------------------------------
+# busca / login / token de convite / força de senha
+# ---------------------------------------------------------------------------
+
+@patch("application.services.service_usuario.Usuario")
+def test_buscar_aluno_por_id(mock_usuario):
+    aluno = MagicMock()
+    aluno.to_dict.return_value = {"id": "1"}
+    mock_usuario.query.get.return_value = aluno
+    assert svc.buscar_aluno(aluno_id="1") == {"id": "1"}
+
+
+@patch("application.services.service_usuario.db")
+@patch("application.services.service_usuario.Usuario")
+def test_buscar_aluno_por_filtros(mock_usuario, mock_db):
+    aluno = MagicMock()
+    aluno.to_dict.return_value = {"email": "a@b.com"}
+    mock_usuario.query.filter.return_value.first.return_value = aluno
+    assert svc.buscar_aluno(email="a@b.com") == {"email": "a@b.com"}
+
+
+@patch("application.services.service_usuario.Usuario")
+def test_buscar_aluno_sem_filtros_retorna_none(mock_usuario):
+    assert svc.buscar_aluno() is None
+
+
+@patch("application.services.service_usuario.check_password_hash", return_value=True)
+@patch("application.services.service_usuario.Usuario")
+def test_logar_aluno_sucesso(mock_usuario, _mock_check):
+    aluno = MagicMock()
+    aluno.to_dict.return_value = {"matricula": "2024"}
+    mock_usuario.query.filter_by.return_value.first.return_value = aluno
+    assert svc.logar_aluno("2024", "senha") == {"matricula": "2024"}
+
+
+@patch("application.services.service_usuario.Usuario")
+def test_logar_aluno_inexistente(mock_usuario):
+    mock_usuario.query.filter_by.return_value.first.return_value = None
+    assert svc.logar_aluno("000", "x") is None
+
+
+@patch("application.services.service_usuario.TokenConvite")
+def test_validar_token_convite_invalido(mock_token):
+    mock_token.query.filter_by.return_value.first.return_value = None
+    dados, status = svc.validar_token_convite("tok")
+    assert dados is None and status == "utilizado_ou_inexistente"
+
+
+@patch("application.services.service_usuario.TokenConvite")
+def test_validar_token_convite_valido(mock_token):
+    registro = MagicMock(used=False)
+    registro.usuario = MagicMock(nome="Ana", email="ana@iesb.edu.br")
+    mock_token.query.filter_by.return_value.first.return_value = registro
+    dados, status = svc.validar_token_convite("tok")
+    assert status == "valido" and dados["nome"] == "Ana"
+
+
+@patch("application.services.service_usuario.db")
+@patch("application.services.service_usuario.generate_password_hash", return_value="hash")
+@patch("application.services.service_usuario.TokenConvite")
+def test_definir_senha_primeiro_acesso_sucesso(mock_token, _mock_hash, mock_db):
+    registro = MagicMock(used=False)
+    usuario = MagicMock()
+    usuario.to_dict.return_value = {"id": "1"}
+    registro.usuario = usuario
+    mock_token.query.filter_by.return_value.first.return_value = registro
+    resultado = svc.definir_senha_primeiro_acesso("tok", "Senha123")
+    assert resultado == {"id": "1"}
+    assert registro.used is True
+    mock_db.session.commit.assert_called_once()
+
+
+def test_definir_senha_primeiro_acesso_senha_fraca():
+    assert svc.definir_senha_primeiro_acesso("tok", "fraca") is None
+
+
+@patch("application.services.service_usuario.TokenConvite")
+def test_definir_senha_primeiro_acesso_token_invalido(mock_token):
+    mock_token.query.filter_by.return_value.first.return_value = None
+    assert svc.definir_senha_primeiro_acesso("tok", "Senha123") is None
+
+
+@pytest.mark.parametrize("senha,ok", [
+    ("Senha123", True),
+    ("curta1A", False),       # < 8
+    ("semmaiuscula1", False),
+    ("SEMMINUSCULA1", False),
+    ("SemNumeroAa", False),
+])
+def test_validar_forca_senha(senha, ok):
+    erro = svc._validar_forca_senha(senha)
+    assert (erro is None) == ok
+
+
+@patch("application.services.service_usuario.Usuario")
+def test_buscar_professor_com_filtros(mock_usuario):
+    q = MagicMock()
+    mock_usuario.query.filter.return_value = q
+    q.filter.return_value = q
+    assert svc.buscar_professor(nome="X", matricula="1") is not None

--- a/backend/application/tests/auth/test_token_denylist.py
+++ b/backend/application/tests/auth/test_token_denylist.py
@@ -1,0 +1,177 @@
+"""
+Testes unitários da denylist de tokens/usuários (logout e desativação).
+
+Cobrem os dois back-ends suportados:
+- fallback em memória (sem REDIS_URL), usado em dev/single-worker;
+- Redis (mockado), incluindo o fallback automático para memória quando o
+  Redis falha em tempo de execução.
+
+Os imports pesados do pacote `application` são stubbados para que o módulo possa
+ser testado isoladamente (mesmo padrão de `test_primeiro_acesso`).
+"""
+import sys
+from unittest.mock import MagicMock
+
+# Stub das libs/módulos pesados puxados por application/__init__.py.
+sys.modules.setdefault("chromadb", MagicMock())
+sys.modules.setdefault("ollama", MagicMock())
+sys.modules.setdefault("application.config.vector_database", MagicMock())
+
+import pytest
+import application.auth.token_denylist as td
+
+
+@pytest.fixture(autouse=True)
+def reset_state(monkeypatch):
+    """Zera o estado global do módulo entre os testes."""
+    monkeypatch.setattr(td, "_redis", None)
+    monkeypatch.setattr(td, "_init_done", False)
+    monkeypatch.setattr(td, "_memoria", set())
+    monkeypatch.setattr(td, "_memoria_usuarios", set())
+    yield
+
+
+# ---------------------------------------------------------------------------
+# _get_redis — inicialização preguiçosa
+# ---------------------------------------------------------------------------
+
+def test_get_redis_sem_url_retorna_none(monkeypatch):
+    monkeypatch.delenv("REDIS_URL", raising=False)
+    assert td._get_redis() is None
+    assert td._init_done is True
+
+
+def test_get_redis_com_url_conecta_e_pinga(monkeypatch):
+    monkeypatch.setenv("REDIS_URL", "redis://localhost:6379")
+    fake_client = MagicMock()
+    fake_redis_mod = MagicMock()
+    fake_redis_mod.from_url.return_value = fake_client
+    monkeypatch.setitem(sys.modules, "redis", fake_redis_mod)
+
+    assert td._get_redis() is fake_client
+    fake_client.ping.assert_called_once()
+
+
+def test_get_redis_falha_na_conexao_cai_para_none(monkeypatch):
+    monkeypatch.setenv("REDIS_URL", "redis://localhost:6379")
+    fake_redis_mod = MagicMock()
+    fake_redis_mod.from_url.side_effect = Exception("connection refused")
+    monkeypatch.setitem(sys.modules, "redis", fake_redis_mod)
+
+    assert td._get_redis() is None
+
+
+def test_get_redis_inicializa_uma_unica_vez(monkeypatch):
+    monkeypatch.setattr(td, "_init_done", True)
+    monkeypatch.setattr(td, "_redis", "cliente-cacheado")
+    assert td._get_redis() == "cliente-cacheado"
+
+
+# ---------------------------------------------------------------------------
+# Fallback em memória (sem Redis)
+# ---------------------------------------------------------------------------
+
+def test_token_invalidado_em_memoria(monkeypatch):
+    monkeypatch.setattr(td, "_get_redis", lambda: None)
+    assert td.token_invalido("tok-1") is False
+    td.invalidar_token("tok-1")
+    assert td.token_invalido("tok-1") is True
+
+
+def test_bloqueio_de_usuario_em_memoria(monkeypatch):
+    monkeypatch.setattr(td, "_get_redis", lambda: None)
+    assert td.usuario_bloqueado("u-1") is False
+    td.bloquear_usuario("u-1")
+    assert td.usuario_bloqueado("u-1") is True
+    td.desbloquear_usuario("u-1")
+    assert td.usuario_bloqueado("u-1") is False
+
+
+def test_bloqueio_normaliza_id_para_string(monkeypatch):
+    monkeypatch.setattr(td, "_get_redis", lambda: None)
+    td.bloquear_usuario(123)
+    assert td.usuario_bloqueado("123") is True
+
+
+# ---------------------------------------------------------------------------
+# Caminho Redis (cliente mockado)
+# ---------------------------------------------------------------------------
+
+def test_invalidar_token_usa_redis_setex(monkeypatch):
+    client = MagicMock()
+    monkeypatch.setattr(td, "_get_redis", lambda: client)
+    td.invalidar_token("tok-1")
+    client.setex.assert_called_once()
+    assert "tok-1" not in td._memoria  # não cai para memória quando Redis ok
+
+
+def test_token_invalido_consulta_redis(monkeypatch):
+    client = MagicMock()
+    client.exists.return_value = 1
+    monkeypatch.setattr(td, "_get_redis", lambda: client)
+    assert td.token_invalido("tok-1") is True
+
+
+def test_bloquear_usuario_usa_redis(monkeypatch):
+    client = MagicMock()
+    monkeypatch.setattr(td, "_get_redis", lambda: client)
+    td.bloquear_usuario("u-1")
+    client.setex.assert_called_once()
+
+
+def test_desbloquear_usuario_usa_redis_delete(monkeypatch):
+    client = MagicMock()
+    monkeypatch.setattr(td, "_get_redis", lambda: client)
+    td.desbloquear_usuario("u-1")
+    client.delete.assert_called_once()
+
+
+def test_usuario_bloqueado_consulta_redis(monkeypatch):
+    client = MagicMock()
+    client.exists.return_value = 1
+    monkeypatch.setattr(td, "_get_redis", lambda: client)
+    assert td.usuario_bloqueado("u-1") is True
+
+
+# ---------------------------------------------------------------------------
+# Redis falha em runtime -> fallback automático para memória
+# ---------------------------------------------------------------------------
+
+def test_invalidar_token_redis_erro_cai_para_memoria(monkeypatch):
+    client = MagicMock()
+    client.setex.side_effect = Exception("redis down")
+    monkeypatch.setattr(td, "_get_redis", lambda: client)
+    td.invalidar_token("tok-1")
+    assert "tok-1" in td._memoria
+
+
+def test_token_invalido_redis_erro_cai_para_memoria(monkeypatch):
+    client = MagicMock()
+    client.exists.side_effect = Exception("redis down")
+    monkeypatch.setattr(td, "_get_redis", lambda: client)
+    td._memoria.add("tok-1")
+    assert td.token_invalido("tok-1") is True
+
+
+def test_bloquear_usuario_redis_erro_cai_para_memoria(monkeypatch):
+    client = MagicMock()
+    client.setex.side_effect = Exception("redis down")
+    monkeypatch.setattr(td, "_get_redis", lambda: client)
+    td.bloquear_usuario("u-1")
+    assert "u-1" in td._memoria_usuarios
+
+
+def test_desbloquear_usuario_redis_erro_nao_quebra(monkeypatch):
+    client = MagicMock()
+    client.delete.side_effect = Exception("redis down")
+    monkeypatch.setattr(td, "_get_redis", lambda: client)
+    # não deve levantar; o discard em memória só roda quando não há cliente
+    td.desbloquear_usuario("u-1")
+
+
+def test_usuario_bloqueado_redis_erro_cai_para_memoria(monkeypatch):
+    client = MagicMock()
+    client.exists.side_effect = Exception("redis down")
+    monkeypatch.setattr(td, "_get_redis", lambda: client)
+    td._memoria_usuarios.add("u-1")
+    assert td.usuario_bloqueado("u-1") is True

--- a/backend/application/tests/libs/test_email_sender.py
+++ b/backend/application/tests/libs/test_email_sender.py
@@ -1,0 +1,144 @@
+"""
+Testes unitários do envio de e-mail (convite e recuperação de senha).
+
+O SMTP é totalmente mockado — nenhum e-mail/conexão real é feito. Cobrem:
+- retry com sucesso, retry esgotado e o guard que evita `raise None`;
+- montagem das mensagens de convite e de recuperação;
+- disparo assíncrono (thread) com tratamento de erro.
+"""
+import sys
+from unittest.mock import MagicMock, patch
+
+sys.modules.setdefault("chromadb", MagicMock())
+sys.modules.setdefault("ollama", MagicMock())
+sys.modules.setdefault("application.config.vector_database", MagicMock())
+
+import pytest
+import application.libs.email_sender as es
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep(monkeypatch):
+    """Evita esperas reais entre tentativas."""
+    monkeypatch.setattr(es.time, "sleep", lambda *_: None)
+
+
+def _smtp_context(server):
+    """Cria um mock de smtplib.SMTP usado como context manager (`with ... as`)."""
+    cm = MagicMock()
+    cm.__enter__.return_value = server
+    cm.__exit__.return_value = False
+    return cm
+
+
+# ---------------------------------------------------------------------------
+# _enviar_mensagem — retry / guard
+# ---------------------------------------------------------------------------
+
+def test_envia_na_primeira_tentativa(monkeypatch):
+    server = MagicMock()
+    smtp = MagicMock(return_value=_smtp_context(server))
+    monkeypatch.setattr(es.smtplib, "SMTP", smtp)
+
+    es._enviar_mensagem(MagicMock(), "dest@iesb.edu.br")
+
+    smtp.assert_called_once()
+    server.login.assert_called_once()
+    server.sendmail.assert_called_once()
+
+
+def test_reenvia_apos_falha_transitoria(monkeypatch):
+    server_ok = MagicMock()
+    # 1ª tentativa falha ao abrir conexão; 2ª funciona.
+    smtp = MagicMock(side_effect=[Exception("timeout"), _smtp_context(server_ok)])
+    monkeypatch.setattr(es.smtplib, "SMTP", smtp)
+    monkeypatch.setattr(es, "SMTP_TENTATIVAS", 3)
+
+    es._enviar_mensagem(MagicMock(), "dest@iesb.edu.br")
+
+    assert smtp.call_count == 2
+    server_ok.sendmail.assert_called_once()
+
+
+def test_levanta_ultimo_erro_quando_todas_falham(monkeypatch):
+    smtp = MagicMock(side_effect=RuntimeError("smtp fora do ar"))
+    monkeypatch.setattr(es.smtplib, "SMTP", smtp)
+    monkeypatch.setattr(es, "SMTP_TENTATIVAS", 2)
+
+    with pytest.raises(RuntimeError, match="smtp fora do ar"):
+        es._enviar_mensagem(MagicMock(), "dest@iesb.edu.br")
+    assert smtp.call_count == 2
+
+
+def test_sem_tentativas_levanta_runtimeerror_explicito(monkeypatch):
+    # Guard contra `raise None`: se o laço nunca executa, erra de forma explícita.
+    monkeypatch.setattr(es, "SMTP_TENTATIVAS", 0)
+    smtp = MagicMock()
+    monkeypatch.setattr(es.smtplib, "SMTP", smtp)
+
+    with pytest.raises(RuntimeError, match="nenhuma tentativa"):
+        es._enviar_mensagem(MagicMock(), "dest@iesb.edu.br")
+    smtp.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Montagem das mensagens (convite e recuperação)
+# ---------------------------------------------------------------------------
+
+def test_enviar_email_convite_monta_e_envia(monkeypatch):
+    enviar = MagicMock()
+    monkeypatch.setattr(es, "_enviar_mensagem", enviar)
+
+    es.enviar_email_convite("aluno@iesb.edu.br", "Maria Silva", "token-123")
+
+    enviar.assert_called_once()
+    msg, destinatario = enviar.call_args.args
+    assert destinatario == "aluno@iesb.edu.br"
+    assert msg["To"] == "aluno@iesb.edu.br"
+    html = msg.get_payload()[0].get_payload(decode=True).decode()
+    assert "token-123" in html
+
+
+def test_enviar_email_recuperacao_monta_e_envia(monkeypatch):
+    enviar = MagicMock()
+    monkeypatch.setattr(es, "_enviar_mensagem", enviar)
+
+    es.enviar_email_recuperacao_senha("aluno@iesb.edu.br", "João", "tok-reset")
+
+    enviar.assert_called_once()
+    msg, destinatario = enviar.call_args.args
+    assert destinatario == "aluno@iesb.edu.br"
+    html = msg.get_payload()[0].get_payload(decode=True).decode()
+    assert "reset=1" in html
+    assert "tok-reset" in html
+
+
+# ---------------------------------------------------------------------------
+# Disparo assíncrono
+# ---------------------------------------------------------------------------
+
+def _thread_sincrona(monkeypatch):
+    """Faz Thread.start() rodar o target de forma síncrona."""
+    def fake_thread(target=None, daemon=None, **_):
+        t = MagicMock()
+        t.start.side_effect = lambda: target()
+        return t
+    monkeypatch.setattr(es.threading, "Thread", fake_thread)
+
+
+def test_envio_async_chama_envio_convite(monkeypatch):
+    _thread_sincrona(monkeypatch)
+    convite = MagicMock()
+    monkeypatch.setattr(es, "enviar_email_convite", convite)
+
+    es.enviar_email_convite_async("a@iesb.edu.br", "Ana", "tok")
+
+    convite.assert_called_once_with("a@iesb.edu.br", "Ana", "tok")
+
+
+def test_envio_async_loga_e_nao_propaga_erro(monkeypatch):
+    _thread_sincrona(monkeypatch)
+    monkeypatch.setattr(es, "enviar_email_convite", MagicMock(side_effect=Exception("falhou")))
+
+    # Não deve propagar a exceção (apenas registra em log).
+    es.enviar_email_convite_async("a@iesb.edu.br", "Ana", "tok")

--- a/backend/application/tests/routes/test_login_google.py
+++ b/backend/application/tests/routes/test_login_google.py
@@ -67,7 +67,8 @@ def test_login_google_usuario_nao_cadastrado(client):
 
         assert response.status_code == 404
         data = response.get_json()
-        assert "não cadastrado" in data["error"].lower()
+        # Mensagem alinhada ao épico/Figma (US-02-RV1).
+        assert "não está vinculada" in data["error"].lower()
 
 
 def test_login_google_sucesso(client):
@@ -84,6 +85,7 @@ def test_login_google_sucesso(client):
         aluno_mock = MagicMock()
         aluno_mock.id = "uuid-fake-123"
         aluno_mock.role.value = "3"
+        aluno_mock.status.name = "ATIVO"  # usuário ativo: necessário p/ passar na checagem de status
         aluno_mock.to_dict.return_value = {
             "id": "uuid-fake-123",
             "matricula": "20260001",

--- a/backend/application/tests/routes/test_primeiro_acesso.py
+++ b/backend/application/tests/routes/test_primeiro_acesso.py
@@ -54,7 +54,7 @@ TOKEN_FAKE = "token-uuid-fake"
 
 class TestCriarUsuario:
 
-    @patch("application.routes.route_admin.enviar_email_convite")
+    @patch("application.routes.route_admin.enviar_email_convite_async")
     @patch("application.routes.route_admin.criar_usuario")
     @patch("application.routes.route_admin.Usuario")
     def test_retorna_201_em_caso_de_sucesso(self, mock_usuario, mock_criar, mock_email, client):
@@ -66,7 +66,7 @@ class TestCriarUsuario:
 
         assert response.status_code == 201
 
-    @patch("application.routes.route_admin.enviar_email_convite")
+    @patch("application.routes.route_admin.enviar_email_convite_async")
     @patch("application.routes.route_admin.criar_usuario")
     @patch("application.routes.route_admin.Usuario")
     def test_dispara_email_com_dados_e_token_corretos(self, mock_usuario, mock_criar, mock_email, client):
@@ -82,7 +82,7 @@ class TestCriarUsuario:
             TOKEN_FAKE,
         )
 
-    @patch("application.routes.route_admin.enviar_email_convite")
+    @patch("application.routes.route_admin.enviar_email_convite_async")
     @patch("application.routes.route_admin.criar_usuario")
     @patch("application.routes.route_admin.Usuario")
     def test_nao_dispara_email_para_usuario_via_google(self, mock_usuario, mock_criar, mock_email, client):

--- a/backend/application/tests/routes/test_primeiro_acesso.py
+++ b/backend/application/tests/routes/test_primeiro_acesso.py
@@ -17,6 +17,7 @@ sys.modules["application.socket.socket_instance"] = MagicMock()
 sys.modules["application.socket.event_handler"] = MagicMock()
 
 from app import app
+from application.auth.jwt_handler import gerar_token
 
 
 # ---------------------------------------------------------------------------
@@ -28,6 +29,14 @@ def client():
     app.config["TESTING"] = True
     with app.test_client() as client:
         yield client
+
+
+@pytest.fixture
+def admin_headers():
+    """JWT de ADMIN — as rotas /usuarios/* passaram a exigir admin autenticado (GAP-02-A)."""
+    with app.app_context():
+        token = gerar_token("00000000-0000-0000-0000-0000000000ad", "ADMIN")
+    return {"Authorization": f"Bearer {token}"}
 
 
 PAYLOAD_CRIAR = {
@@ -57,24 +66,24 @@ class TestCriarUsuario:
     @patch("application.routes.route_admin.enviar_email_convite_async")
     @patch("application.routes.route_admin.criar_usuario")
     @patch("application.routes.route_admin.Usuario")
-    def test_retorna_201_em_caso_de_sucesso(self, mock_usuario, mock_criar, mock_email, client):
+    def test_retorna_201_em_caso_de_sucesso(self, mock_usuario, mock_criar, mock_email, client, admin_headers):
         """Retorna 201 Created ao criar usuário com dados válidos."""
         mock_usuario.query.filter.return_value.first.return_value = None
         mock_criar.return_value = (USUARIO_DICT, TOKEN_FAKE)
 
-        response = client.post("/admin/usuarios/criar", json=PAYLOAD_CRIAR)
+        response = client.post("/admin/usuarios/criar", json=PAYLOAD_CRIAR, headers=admin_headers)
 
         assert response.status_code == 201
 
     @patch("application.routes.route_admin.enviar_email_convite_async")
     @patch("application.routes.route_admin.criar_usuario")
     @patch("application.routes.route_admin.Usuario")
-    def test_dispara_email_com_dados_e_token_corretos(self, mock_usuario, mock_criar, mock_email, client):
+    def test_dispara_email_com_dados_e_token_corretos(self, mock_usuario, mock_criar, mock_email, client, admin_headers):
         """Dispara o e-mail de convite com e-mail, nome e token corretos."""
         mock_usuario.query.filter.return_value.first.return_value = None
         mock_criar.return_value = (USUARIO_DICT, TOKEN_FAKE)
 
-        client.post("/admin/usuarios/criar", json=PAYLOAD_CRIAR)
+        client.post("/admin/usuarios/criar", json=PAYLOAD_CRIAR, headers=admin_headers)
 
         mock_email.assert_called_once_with(
             PAYLOAD_CRIAR["email"],
@@ -85,32 +94,47 @@ class TestCriarUsuario:
     @patch("application.routes.route_admin.enviar_email_convite_async")
     @patch("application.routes.route_admin.criar_usuario")
     @patch("application.routes.route_admin.Usuario")
-    def test_nao_dispara_email_para_usuario_via_google(self, mock_usuario, mock_criar, mock_email, client):
+    def test_nao_dispara_email_para_usuario_via_google(self, mock_usuario, mock_criar, mock_email, client, admin_headers):
         """Não dispara e-mail de convite quando via_google=True."""
         mock_usuario.query.filter.return_value.first.return_value = None
         mock_criar.return_value = (USUARIO_DICT, None)
 
-        client.post("/admin/usuarios/criar", json={**PAYLOAD_CRIAR, "via_google": True})
+        client.post("/admin/usuarios/criar", json={**PAYLOAD_CRIAR, "via_google": True}, headers=admin_headers)
 
         mock_email.assert_not_called()
 
     @patch("application.routes.route_admin.Usuario")
-    def test_email_fora_do_dominio_retorna_400(self, mock_usuario, client):
+    def test_email_fora_do_dominio_retorna_400(self, mock_usuario, client, admin_headers):
         """Rejeita e-mail fora do domínio @iesb.edu.br com 400."""
         payload = {**PAYLOAD_CRIAR, "email": "aluno@gmail.com"}
 
-        response = client.post("/admin/usuarios/criar", json=payload)
+        response = client.post("/admin/usuarios/criar", json=payload, headers=admin_headers)
 
         assert response.status_code == 400
 
     @patch("application.routes.route_admin.Usuario")
-    def test_usuario_duplicado_retorna_409(self, mock_usuario, client):
+    def test_usuario_duplicado_retorna_409(self, mock_usuario, client, admin_headers):
         """Retorna 409 quando matrícula ou e-mail já existem no banco."""
         mock_usuario.query.filter.return_value.first.return_value = MagicMock()
 
-        response = client.post("/admin/usuarios/criar", json=PAYLOAD_CRIAR)
+        response = client.post("/admin/usuarios/criar", json=PAYLOAD_CRIAR, headers=admin_headers)
 
         assert response.status_code == 409
+
+    def test_sem_token_retorna_401(self, client):
+        """Sem autenticação a criação é bloqueada no backend (GAP-02-A)."""
+        response = client.post("/admin/usuarios/criar", json=PAYLOAD_CRIAR)
+        assert response.status_code == 401
+
+    def test_perfil_nao_admin_retorna_403(self, client):
+        """Usuário autenticado que não é admin não pode criar (GAP-02-A)."""
+        with app.app_context():
+            token = gerar_token("11111111-1111-1111-1111-111111111111", "PROFESSOR")
+        response = client.post(
+            "/admin/usuarios/criar", json=PAYLOAD_CRIAR,
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert response.status_code == 403
 
 
 # ---------------------------------------------------------------------------

--- a/backend/application/tests/routes/test_route_auth.py
+++ b/backend/application/tests/routes/test_route_auth.py
@@ -1,0 +1,101 @@
+"""
+Testes de rota para autenticação (set-password e forgot-password).
+
+Tudo mockado (sem banco): valida os fluxos de criação/redefinição de senha e de
+recuperação por e-mail, incluindo o caminho de sucesso que emite o cookie de sessão.
+"""
+import sys
+from unittest.mock import MagicMock, patch
+import pytest
+
+sys.modules.setdefault("application.config.vector_database", MagicMock())
+sys.modules.setdefault("chromadb", MagicMock())
+sys.modules.setdefault("ollama", MagicMock())
+sys.modules.setdefault("application.socket.socket_instance", MagicMock())
+sys.modules.setdefault("application.socket.event_handler", MagicMock())
+
+from app import app
+from application.models.model_usuario import StatusEnum
+
+
+@pytest.fixture
+def client():
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield c
+
+
+# ---------------------------------------------------------------------------
+# POST /auth/invite/set-password
+# ---------------------------------------------------------------------------
+
+def test_set_password_parametros_ausentes(client):
+    resp = client.post("/auth/invite/set-password", json={})
+    assert resp.status_code == 400
+
+
+def test_set_password_confirmacao_divergente(client):
+    resp = client.post("/auth/invite/set-password", json={
+        "token": "tok", "senha": "Senha123", "confirmacao": "Outra123",
+    })
+    assert resp.status_code == 422
+
+
+@patch("application.routes.route_auth.validar_token_convite", return_value=(None, "utilizado_ou_inexistente"))
+def test_set_password_token_invalido(_mock_validar, client):
+    resp = client.post("/auth/invite/set-password", json={"token": "tok", "senha": "Senha123"})
+    assert resp.status_code == 410
+
+
+@patch("application.routes.route_auth.definir_senha_primeiro_acesso", return_value=None)
+@patch("application.routes.route_auth.validar_token_convite", return_value=(None, "valido"))
+def test_set_password_senha_fraca(_mock_validar, _mock_definir, client):
+    resp = client.post("/auth/invite/set-password", json={"token": "tok", "senha": "fraca"})
+    assert resp.status_code == 422
+
+
+@patch("application.routes.route_auth.definir_cookie_sessao")
+@patch("application.routes.route_auth.gerar_token", return_value="jwt-fake")
+@patch("application.routes.route_auth.definir_senha_primeiro_acesso",
+       return_value={"id": "u1", "role": "ALUNO"})
+@patch("application.routes.route_auth.validar_token_convite", return_value=(None, "valido"))
+def test_set_password_sucesso_emite_sessao(_mock_validar, _mock_definir, mock_gerar, mock_cookie, client):
+    resp = client.post("/auth/invite/set-password", json={
+        "token": "tok", "senha": "Senha123", "confirmacao": "Senha123",
+    })
+    assert resp.status_code == 200
+    assert resp.get_json()["usuario"]["id"] == "u1"
+    mock_gerar.assert_called_once_with("u1", "ALUNO")
+    mock_cookie.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# POST /auth/forgot-password
+# ---------------------------------------------------------------------------
+
+def test_forgot_password_email_ausente(client):
+    resp = client.post("/auth/forgot-password", json={})
+    assert resp.status_code == 400
+
+
+@patch("application.routes.route_auth.enviar_email_recuperacao_senha")
+@patch("application.routes.route_auth.db")
+@patch("application.routes.route_auth.TokenConvite")
+@patch("application.routes.route_auth.Usuario")
+def test_forgot_password_usuario_ativo_gera_token_e_envia(mock_usuario, mock_token, mock_db, mock_email, client):
+    usuario = MagicMock(id="u1", email="a@iesb.edu.br", nome="Ana", status=StatusEnum.ATIVO)
+    mock_usuario.query.filter_by.return_value.first.return_value = usuario
+
+    resp = client.post("/auth/forgot-password", json={"email": "a@iesb.edu.br"})
+
+    assert resp.status_code == 200
+    mock_email.assert_called_once()
+    assert mock_db.session.commit.called
+
+
+@patch("application.routes.route_auth.Usuario")
+def test_forgot_password_email_desconhecido_responde_generico(mock_usuario, client):
+    # não revela se o e-mail existe — resposta genérica 200
+    mock_usuario.query.filter_by.return_value.first.return_value = None
+    resp = client.post("/auth/forgot-password", json={"email": "naoexiste@iesb.edu.br"})
+    assert resp.status_code == 200

--- a/backend/application/tests/socket/test_event_handler.py
+++ b/backend/application/tests/socket/test_event_handler.py
@@ -1,0 +1,122 @@
+"""
+Testes do handshake autenticado do WebSocket (GAP-06-F).
+
+Cobrem a autenticação por cookie no connect, o registro/baixa da identidade por
+`sid` e a rejeição de mensagens sem sessão autenticada. Tudo mockado — não há
+servidor socket.io real.
+"""
+import sys
+import importlib
+from unittest.mock import MagicMock, patch
+
+# Stub das libs externas pesadas (mas NÃO de socket_instance/event_handler, que
+# precisam ser reais para os @socketio.on devolverem as funções de verdade).
+sys.modules.setdefault("chromadb", MagicMock())
+sys.modules.setdefault("ollama", MagicMock())
+sys.modules.setdefault("application.config.vector_database", MagicMock())
+
+# Outros testes podem ter stubado estes módulos em sys.modules; garante os reais.
+for _m in ("application.socket.event_handler", "application.socket.socket_instance"):
+    if isinstance(sys.modules.get(_m), MagicMock):
+        del sys.modules[_m]
+
+import application.socket.socket_instance  # noqa: E402  (garante módulo real)
+import application.socket.event_handler as eh  # noqa: E402
+
+if isinstance(eh, MagicMock) or not hasattr(eh, "_autenticar_handshake"):
+    eh = importlib.reload(importlib.import_module("application.socket.event_handler"))
+
+import pytest  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _limpa_sessoes():
+    eh.SOCKET_USUARIOS.clear()
+    yield
+    eh.SOCKET_USUARIOS.clear()
+
+
+# ---------------------------------------------------------------------------
+# _autenticar_handshake
+# ---------------------------------------------------------------------------
+
+def test_handshake_sem_token_retorna_none():
+    with patch.object(eh, "extrair_token", return_value=None):
+        assert eh._autenticar_handshake() is None
+
+
+def test_handshake_token_na_denylist_retorna_none():
+    with patch.object(eh, "extrair_token", return_value="tok"), \
+         patch.object(eh, "token_invalido", return_value=True):
+        assert eh._autenticar_handshake() is None
+
+
+def test_handshake_payload_invalido_retorna_none():
+    with patch.object(eh, "extrair_token", return_value="tok"), \
+         patch.object(eh, "token_invalido", return_value=False), \
+         patch.object(eh, "validar_token", return_value=None):
+        assert eh._autenticar_handshake() is None
+
+
+def test_handshake_sucesso_retorna_user_id():
+    with patch.object(eh, "extrair_token", return_value="tok"), \
+         patch.object(eh, "token_invalido", return_value=False), \
+         patch.object(eh, "validar_token", return_value={"user_id": "u-42"}):
+        assert eh._autenticar_handshake() == "u-42"
+
+
+# ---------------------------------------------------------------------------
+# connect / disconnect
+# ---------------------------------------------------------------------------
+
+def test_connect_rejeita_sem_autenticacao():
+    with patch.object(eh, "_autenticar_handshake", return_value=None):
+        assert eh.handle_connect() is False
+
+
+def test_connect_registra_identidade_e_confirma():
+    fake_req = MagicMock(sid="sid-1")
+    with patch.object(eh, "_autenticar_handshake", return_value="u-1"), \
+         patch.object(eh, "request", fake_req), \
+         patch.object(eh, "emit") as mock_emit:
+        eh.handle_connect()
+    assert eh.SOCKET_USUARIOS["sid-1"] == "u-1"
+    mock_emit.assert_called_once()
+
+
+def test_disconnect_remove_identidade():
+    eh.SOCKET_USUARIOS["sid-1"] = "u-1"
+    fake_req = MagicMock(sid="sid-1")
+    with patch.object(eh, "request", fake_req):
+        eh.handle_disconnect()
+    assert "sid-1" not in eh.SOCKET_USUARIOS
+
+
+# ---------------------------------------------------------------------------
+# maestro (mensagem_inicial)
+# ---------------------------------------------------------------------------
+
+def test_maestro_sem_sessao_emite_sessao_expirada():
+    fake_req = MagicMock(sid="sid-x")
+    with patch.object(eh, "request", fake_req), \
+         patch.object(eh, "disparar_emit") as mock_disp:
+        eh.maestro({"id_usuario": "qualquer"})
+    evento = mock_disp.call_args.args[1]
+    assert evento == "sessao_expirada"
+
+
+def test_maestro_autenticado_agenda_processamento_com_identidade_do_servidor():
+    eh.SOCKET_USUARIOS["sid-1"] = "u-real"
+    fake_req = MagicMock(sid="sid-1")
+    fake_socketio = MagicMock()
+    fake_app = MagicMock()
+    fake_app._get_current_object.return_value = "app-obj"
+    with patch.object(eh, "request", fake_req), \
+         patch.object(eh, "socketio", fake_socketio), \
+         patch.object(eh, "current_app", fake_app):
+        # id_usuario do payload deve ser ignorado em favor da identidade do handshake
+        eh.maestro({"id_usuario": "id-forjado", "mensagem": "oi"})
+
+    fake_socketio.start_background_task.assert_called_once()
+    data_arg = fake_socketio.start_background_task.call_args.args[1]
+    assert data_arg["id_usuario"] == "u-real"

--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -1,6 +1,19 @@
 import sys
 import os
+from unittest.mock import MagicMock
 
 # Garante que o diretório raiz do backend esteja no PYTHONPATH,
 # permitindo que todos os testes encontrem os módulos 'app' e 'application'.
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+# IMPORTANTE: este conftest fica FORA do pacote `application`, então é carregado
+# pelo pytest antes de qualquer módulo de teste importar `application`. Stubamos
+# aqui `application.config.vector_database`, cujo corpo roda no import
+# `os.makedirs("/data/chroma")` + `PersistentClient(...)`. No CI (Linux, usuário
+# sem permissão em `/`) esse makedirs levanta PermissionError e, como o módulo
+# está na cadeia `application → routes → service_arquivo → vector_database`,
+# derruba a coleta de TODOS os testes que importam `application`/`app`.
+# Substituindo o módulo inteiro por um mock, o corpo nunca executa.
+sys.modules["application.config.vector_database"] = MagicMock()
+sys.modules.setdefault("chromadb", MagicMock())
+sys.modules.setdefault("ollama", MagicMock())

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = application/tests

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -20,3 +20,4 @@ httpx
 gunicorn
 gevent
 gevent-websocket
+redis

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -28,6 +28,15 @@ services:
       - ollama_data_dev:/root/.ollama
     profiles: ["llm"]
 
+  redis-service:
+    image: redis:7-alpine
+    container_name: tutor_redis_dev
+    restart: unless-stopped
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data_dev:/data
+
   backend:
     build:
       context: ./backend
@@ -40,9 +49,12 @@ services:
       - FLASK_APP=app:app
       - PYTHONUNBUFFERED=1
       - OLLAMA_HOST=http://ollama-service:11434
+      - REDIS_URL=redis://redis-service:6379/0
     depends_on:
       postgres-service:
         condition: service_healthy
+      redis-service:
+        condition: service_started
     ports:
       - "5000:5000"
     volumes:
@@ -76,6 +88,7 @@ services:
 volumes:
   postgres_data_dev:
   ollama_data_dev:
+  redis_data_dev:
   backend_pycache:
   frontend_node_modules:
   frontend_next_cache:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -60,6 +60,7 @@ services:
     volumes:
       - ./backend:/app
       - backend_pycache:/app/__pycache__
+      - chroma_data_dev:/data
     entrypoint: ["/app/entrypoint.sh"]
     # Worker com suporte a WebSocket (igual à produção) — o `flask run` do Werkzeug
     # não faz upgrade de WebSocket. `--reload` mantém o hot-reload do dev.
@@ -92,5 +93,6 @@ volumes:
   ollama_data_dev:
   redis_data_dev:
   backend_pycache:
+  chroma_data_dev:
   frontend_node_modules:
   frontend_next_cache:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -61,7 +61,9 @@ services:
       - ./backend:/app
       - backend_pycache:/app/__pycache__
     entrypoint: ["/app/entrypoint.sh"]
-    command: ["flask", "run", "--host=0.0.0.0", "--port=5000", "--debug"]
+    # Worker com suporte a WebSocket (igual à produção) — o `flask run` do Werkzeug
+    # não faz upgrade de WebSocket. `--reload` mantém o hot-reload do dev.
+    command: ["gunicorn", "-k", "geventwebsocket.gunicorn.workers.GeventWebSocketWorker", "-w", "1", "app:app", "--bind", "0.0.0.0:5000", "--reload", "--log-level", "info"]
 
   frontend:
     image: node:20-alpine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,13 @@ services:
     volumes:
       - ollama_data:/root/.ollama
 
+  redis-service:
+    image: redis:7-alpine
+    container_name: tutor_redis_prod
+    restart: always
+    volumes:
+      - redis_data_prod:/data
+
   backend:
     build:
       context: ./backend
@@ -34,9 +41,11 @@ services:
       - .env
     environment:
       - OLLAMA_HOST=http://ollama-service:11434
+      - REDIS_URL=redis://redis-service:6379/0
     depends_on:
       - postgres-service
       - ollama-service
+      - redis-service
     ports:
       - "5000:5000"
 
@@ -59,3 +68,4 @@ services:
 volumes:
   postgres_data_prod:
   ollama_data:
+  redis_data_prod:

--- a/docs/epicos/EP01-autenticacao.md
+++ b/docs/epicos/EP01-autenticacao.md
@@ -5,6 +5,7 @@
 |--------|-----------|---------------|-----------|
 | 1.2 Sprint 2 | 19/04/2026 | Login US-01 e US-02, Criação de senha via link de convite US-03 e Encerramento de sessão US-05 | Patricia Pereira Martins |
 | 1.3 Sprint 3 | 10/05/2026 | Inclusão do histórico de revisão | Patricia Pereira Martins |
+| 1.4 Sprint 3 | 30/05/2026 | Alinhamento dos textos de interface ao protótipo do Figma (US-01-RI1: rótulo "Matrícula"; US-03-RI1: título "Defina sua senha" / subtítulo "Escolha uma senha segura para acessar a plataforma.") e ajuste da regra de expiração de sessão (US-05-RN2: período "configurável", sem exigir ajuste pelo administrador) | Patricia Pereira Martins |
 
 ---
 
@@ -47,7 +48,7 @@
 ### Regras de Interface
 
 - A tela de login deve ser a primeira página exibida para usuários não autenticados.
-- Deve haver um campo de matrícula institucional com texto de orientação: _"Matrícula institucional"_.
+- Deve haver um campo para a matrícula institucional com o rótulo: _"Matrícula"_ (conforme protótipo no Figma).
 - O botão de entrar deve estar desabilitado enquanto os campos obrigatórios estiverem em branco.
 - A tela deve exibir o link "Esqueci minha senha" abaixo do formulário.
 - A tela deve exibir a opção de login com Google (ver US-02).
@@ -144,7 +145,7 @@
 ### Regras de Interface
 
 - O e-mail de convite deve conter o nome do usuário, o nome da plataforma e um botão ou link com o texto "Criar minha senha".
-- A tela de criação de senha deve deixar claro o contexto: _"Bem-vindo! Crie uma senha para acessar a plataforma."_
+- A tela de criação de senha deve deixar claro o contexto, com o título _"Defina sua senha"_ e o subtítulo _"Escolha uma senha segura para acessar a plataforma."_ (conforme protótipo no Figma — a mesma tela é usada no primeiro acesso e na recuperação de senha).
 - Devem existir dois campos: "Nova senha" e "Confirmar nova senha", ambos com opção de visualizar o conteúdo.
 - O botão de confirmar deve estar desabilitado até que os requisitos mínimos sejam atendidos.
 
@@ -179,7 +180,7 @@
 ### Regras de Negócio
 
 - O usuário pode encerrar sua sessão voluntariamente a qualquer momento clicando em "Sair".
-- A sessão expira automaticamente após um período configurável de inatividade (definido pelo administrador da plataforma).
+- A sessão expira automaticamente após um período configurável de inatividade (valor de configuração da plataforma; não precisa ser ajustável pelo administrador).
 - Após o encerramento ou expiração, o usuário é redirecionado para a tela de login.
 - Sessões expiradas não permitem continuar usando a plataforma sem novo login.
 

--- a/docs/epicos/EP02-gestao-usuarios.md
+++ b/docs/epicos/EP02-gestao-usuarios.md
@@ -5,6 +5,7 @@
 |--------|-----------|---------------|-----------|
 | 1.2 Sprint 2 | 19/04/2026 | Criação das histórias de usuário US-08 e US-09 | Patricia Pereira Martins |
 | 1.3 Sprint 3 | 08/05/2026 | Criação das histórias de usuário US-07 | Patricia Pereira Martins |
+| 1.4 Sprint 3 | 30/05/2026 | Alinhamento das regras de interface de cadastro (US-07-RI2/US-08-RI2) ao protótipo do Figma: confirmação via toast ao retornar à listagem, sem ação "cadastrar outro" | Patricia Pereira Martins |
 
 ---
 
@@ -47,7 +48,7 @@
 ### Regras de Interface
 
 - O formulário de cadastro de professor deve conter os campos: Nome completo, Matrícula, E-mail.
-- Ao concluir o cadastro, exibir confirmação e opção de cadastrar outro professor ou voltar à listagem.
+- Ao concluir o cadastro, retornar à listagem de professores exibindo uma confirmação (toast): _"Professor cadastrado! Um link de convite foi enviado para o e-mail informado."_ (conforme protótipo no Figma — não há ação de "cadastrar outro").
 
 ### Requisitos Não Funcionais
 
@@ -91,7 +92,7 @@
 
 - O formulário de cadastro de aluno deve conter os campos: Nome completo, Matrícula, E-mail.
 - O sistema envia automaticamente um link de convite para o e-mail do aluno ao concluir o cadastro.
-- Ao concluir o cadastro, exibir confirmação e opção de cadastrar outro aluno ou voltar à listagem.
+- Ao concluir o cadastro, retornar à listagem de alunos exibindo uma confirmação (toast): _"Aluno cadastrado! Um link de convite foi enviado para o e-mail informado."_ (conforme protótipo no Figma — não há ação de "cadastrar outro").
 - A listagem de alunos exibe uma caixa de pesquisa (acima da tabela) e paginação navegável (abaixo da tabela), com botões "Anterior", números de página e "Próximo".
 
 ### Requisitos Não Funcionais

--- a/docs/epicos/EP03-gestao-materias-turmas.md
+++ b/docs/epicos/EP03-gestao-materias-turmas.md
@@ -5,6 +5,7 @@
 |--------|-----------|---------------|-----------|
 | 1.3 Sprint 3 | 10/05/2026 | Cadastro, edição e desativação de matéria US-10 e US-10b, Cadastro de turma US-11, Associação de matéria a turma US-12, Vinculação de professor a turma e matéria US-13 e Matrícula de aluno em turma US-14 | Patricia Pereira Martins |
 | 1.4 Sprint 3 | 19/05/2026 | Refatoração do modelo de associação para alinhar com o diagrama: US-12 passa a vincular professor↔matéria (entidade MateriaProfessor) e US-13 oferta a dupla (Professor+Matéria) a uma turma (entidade MateriaProfessorTurma). Ajustes terminológicos em US-14. | Patricia Pereira Martins |
+| 1.5 Sprint 3 | 30/05/2026 | Alinhamento do texto de confirmação de desativação de matéria (US-10b-RI1) ao protótipo do Figma | Patricia Pereira Martins |
 
 ---
 
@@ -83,7 +84,7 @@
 ### Regras de Interface
 
 - Na listagem de matérias, cada linha deve ter opções de "Editar" e "Desativar" (ou "Reativar" para matérias desativadas).
-- A ação de desativar deve solicitar confirmação: _"Tem certeza que deseja desativar a matéria [nome]? O acesso ao chat e aos materiais será suspenso."_
+- A ação de desativar deve solicitar confirmação: _"Tem certeza que deseja desativar a matéria [nome]? A matéria fica inacessível para chat e gerenciamento de materiais. Todo o histórico é preservado e pode ser restaurado ao reativar."_ (conforme protótipo no Figma)
 - Matérias desativadas devem ser identificadas visualmente na listagem.
 
 ### Requisitos Não Funcionais

--- a/docs/relatorio-gap-epicos-vs-codigo.md
+++ b/docs/relatorio-gap-epicos-vs-codigo.md
@@ -1,0 +1,582 @@
+# Relatório de GAP - Épicos vs Código
+
+> **Projeto Tutor** — Análise de conformidade funcional e técnica
+> **Escopo primário:** `docs/epicos/` (EP-01, EP-02, EP-03, EP-06, EP-09)
+> **Referências complementares:** `docs/rbac.md`, `docs/sitemap.md`, `docs/visao.md`
+> **Data da análise:** 2026-05-30
+> **Método:** análise por épico + verificação adversarial (releitura do código citado) + varredura transversal.
+
+---
+
+## Sumário Executivo
+
+### Aderência geral estimada
+
+| Épico | Aderência estimada |
+|-------|:------------------:|
+| EP-01 — Autenticação e Controle de Acesso | **~72%** |
+| EP-02 — Gestão de Usuários | **~55%** |
+| EP-03 — Gestão de Matérias e Turmas (v1.4) | **~52%** |
+| EP-06 — Chat Educacional | **~45%** |
+| EP-09 — Gestão do Modelo de IA | **~28%** |
+| **Aderência média ponderada** | **~50%** |
+
+### Épicos mais completos
+- **EP-01 (Autenticação)** — login matrícula/senha, login Google, convite/primeiro acesso, hashing e expiração de token estão majoritariamente implementados e coerentes; falhas concentradas em sessão por inatividade e textos de mensagem.
+- **EP-02 (Gestão de Usuários)** — o fluxo de cadastro/edição/desativação está presente no frontend e parcialmente no backend, mas comprometido por falhas graves de autorização no backend.
+
+### Épicos mais incompletos
+- **EP-09 (Gestão do Modelo de IA)** — funcionalidade central (scraping da biblioteca Ollama, consulta de instalados, pull/download, UI do catálogo) **ausente**; tela vazia; **a migration da coluna `status` na tabela `llm` não existe**, o que quebra todo o fluxo em ambiente migrado.
+- **EP-06 (Chat Educacional)** — UI presente, mas o **núcleo de RAG está quebrado em runtime** (bug em `busca_semantica.py:57`), a **detecção de baixa confiança é ausente** (a IA pode alucinar), e faltam limite de 1.000 caracteres e janela de 10 trocas.
+
+### Principais riscos funcionais
+1. **EP-09:** migration ausente da coluna `status` em `llm` → `ativar_modelo`/`getActiveModel` e o chat falham em produção (deploy roda apenas `flask db upgrade`). *(EP-09 GAP-01)*
+2. **EP-06:** `busca_semantica.py:57` usa `asyncio.to_thread(buscar_no_vector_db(...))` — chama a função e passa o **resultado** como callable → `TypeError` em runtime sempre que há material indexado; o RAG nunca recupera contexto. *(EP-06 GAP-02)*
+3. **EP-06:** sem gate de baixa confiança (bloco de contexto vazio comentado; `MCPPipeline.valid_stream` nunca usado) → IA responde sem embasamento. *(EP-06 GAP-01)*
+4. **EP-03:** modelo de associação v1.4 (entidades `MateriaProfessor` US-12 e `MateriaProfessorTurma` US-13) **inexistente**; sem tela de detalhe de turma; sem oferta, sem desmatrícula. *(EP-03 G1/G2/G4)*
+5. **EP-09:** catálogo dinâmico, pull e UI ausentes; tela `catalogoLLM` vazia. *(EP-09 GAP-02/03/04)*
+
+### Principais riscos de autorização/segurança (ligados aos épicos)
+1. **CRÍTICO — EP-02:** rotas de gestão de usuários (`/usuarios/criar`, `/all`, `/<id>`, `/delete/<id>`, `/reativar`) **sem `@token_obrigatorio`/`@apenas_admins`** → API pública: qualquer um lista, cria, edita, desativa e reativa usuários. *(EP-02 GAP-01)*
+2. **CRÍTICO — EP-03:** `POST /alunos_turmas` com `@apenas_alunos` **comentado** → qualquer usuário autenticado matricula alunos. *(EP-03 G3)*
+3. **CRÍTICO/ALTO — EP-01 + EP-03:** `apenas_professores`/`apenas_alunos` comparam `g.usuario_role` contra `'1'/'2'/'3'`, mas o JWT grava o **nome** (`'PROFESSOR'/'ALUNO'`) → decorators **sempre negam (403)**; RBAC de professor/aluno quebrado (rotas de arquivos e de associação/oferta inacessíveis). *(EP-01 GAP-02 / EP-03 G7)*
+4. **CRÍTICO — EP-02:** ao desativar um usuário, a sessão (JWT) ativa **não é encerrada** → acesso mantido por ~60 min. *(EP-02 GAP-02)*
+5. **CRÍTICO — EP-02:** admin pode **desativar a própria conta** (sem verificação; endpoint sequer identifica o solicitante). *(EP-02 GAP-03)*
+6. **ALTO — EP-06:** o socket de chat valida apenas o formato UUID de `materia_id`, **não a matrícula** → aluno pode consultar matéria não matriculada. *(EP-06 GAP-06)*
+7. **ALTO — EP-09:** `route_llm` sem proteção de auth (endpoint público). *(EP-09 GAP-06)*
+
+> **Padrão recorrente:** a maioria das regras de autorização e validação está protegida **apenas no frontend** (middleware/forms), com o backend exposto ou inconsistente. Isso afeta EP-01, EP-02, EP-03, EP-06 e EP-09.
+
+---
+
+## Matriz de Conformidade por Épico
+
+Legenda de status: **Implementado** · **Parcial** · **Ausente** · **Divergente** · **Não verificável**
+
+### EP-01 — Autenticação e Controle de Acesso (US-01, US-02, US-03, US-05)
+
+| ID / US | Requisito (épico) | Status | Evid. épico | Evid. código | Observação |
+|---|---|---|---|---|---|
+| US-01-RN1 | Login por matrícula (identificador) + senha obrigatória | Implementado | EP01:31-32 | `route_usuarios.py:179-183`; `service_usuario.py:80-85`; `login/page.tsx:111` | Backend exige ambos (400); botão desabilitado com campos vazios. |
+| US-01-RN2 | Apenas usuários ativos logam; desativados bloqueados | Implementado | EP01:33-34 | `route_usuarios.py:189-190` (403) | `service_aluno.ts:112` mapeia 403→deactivated. |
+| US-01-RN3 | Redirecionar por perfil (admin/professor/aluno) | Implementado | EP01:35-38 | `utils/roles.ts:16-20`; `login/page.tsx:52-57`; `middleware.ts:47-49` | JWT grava `role.name`; redirect casa. Mismatch de role afeta autorização (GAP-02), não o redirect. |
+| US-01-RN4 | Mensagem genérica de credenciais (não revela campo) | Implementado | EP01:44 | `route_usuarios.py:185-187`; `login/page.tsx:46` | `logar_aluno` retorna None p/ matrícula inexistente e senha errada. |
+| US-01-RV1 | Campo de senha oculto com opção de visualizar | Implementado | EP01:45 | `components/Input/Input.tsx:61-72` | Toggle Eye/EyeOff automático p/ `type='password'`. |
+| US-01-RI1 | Login 1ª tela; botão desabilitado; "Esqueci minha senha"; Google; erro abaixo do form | Parcial | EP01:49-54 | `middleware.ts:39-43`; `login/page.tsx:111,154-156,174-189,219-225` | Label "Matrícula" (não "Matrícula institucional"); erro via Toast, não "abaixo do formulário". |
+| US-01-RNF1 | Senhas com hashing | Implementado | EP01:60 | `service_usuario.py:4,22,168,83` | `generate_password_hash`/`check_password_hash` (werkzeug). |
+| US-01-RNF2 | Comunicação protegida (HTTPS) | Não verificável | EP01:59 | `route_usuarios.py:139,202` (`secure=False`); `route_admin.py:359` | Cookie JWT `secure=False`; depende de TLS no ambiente. |
+| US-01-RNF3 | Sessão expira por inatividade configurável | Parcial | EP01:61 | `jwt_handler.py:5,19`; `route_usuarios.py:141,204` | Expiração **absoluta** de 60 min hardcoded, não por inatividade nem configurável. |
+| US-02-RN1 | Google só p/ usuário ativo; e-mail deve corresponder; não cria usuário | Implementado | EP01:85-87 | `route_usuarios.py:119-127`; `test_login_google.py:106-122` | 404 se inexistente, 403 se inativo; não cria. |
+| US-02-RV1 | Mensagem específica "conta Google não vinculada... contate o admin" | Divergente | EP01:92 | `route_usuarios.py:121-124`; `service_aluno.ts:127-130` | Backend retorna 404 c/ texto diferente; front mapeia só 401/403, 404 vira "unknown". |
+| US-02-RV2 | Usuário desativado bloqueado também no Google | Implementado | EP01:93 | `route_usuarios.py:126-127`; `service_aluno.ts:128` | 403→deactivated. |
+| US-02-RI1 | Botão Google separado; mensagem de falha específica | Divergente | EP01:97-99 | `login/page.tsx:168-189,102-105,48` | Botão presente/separado, mas textos de falha não correspondem ao épico. |
+| US-02-PRE1 | Plataforma configurada p/ Google (config técnica) | Implementado | EP01:109 | `route_usuarios.py:100-105`; `login/page.tsx:33,199-216` | `verify_oauth2_token` com `GOOGLE_CLIENT_ID`. |
+| US-03-RN1 | Gera link de convite único e envia por e-mail | Implementado | EP01:128 | `service_usuario.py:36-43`; `route_admin.py:130-136`; `email_sender.py:29` | Token UUID + e-mail com "Criar minha senha". |
+| US-03-RN2 | Link de uso único; expira só após uso; sem prazo | Implementado | EP01:129-130 | `model_token_convite.py:15`; `service_usuario.py:163-169,145-153` | Só flag `used`, sem expiração temporal. |
+| US-03-RN3 | Após criar senha, link invalidado e redireciona à home do perfil | Divergente | EP01:131-132 | `alterar-senha/page.tsx:76,90`; `route_auth.py:110-118` | Fluxo usado (`/auth/invite/set-password`) **não inicia sessão**; redireciona a `/login`. |
+| US-03-RN4 | Fluxo só p/ login matrícula+senha (Google não cria senha) | Implementado | EP01:134 | `service_usuario.py:36`; `route_admin.py:132` | Flag `via_google` controla. |
+| US-03-RV1 | Senha forte (8+, maiúscula/minúscula/número); confirmação dupla | Parcial | EP01:138-141 | `service_usuario.py:176-186`; `alterar-senha/page.tsx:21-29`; `route_auth.py:96-98` | Endpoint usado não recebe/valida `passwordConfirmation` no backend; mensagem literal ausente. |
+| US-03-RV2 | Link já usado → orientar "Esqueci minha senha" | Implementado | EP01:142 | `route_auth.py:47-51,104-108`; `token-validate/page.tsx:38-42` | 410 Gone com orientação. |
+| US-03-RI1 | E-mail de convite + tela de boas-vindas + 2 campos com visualizar | Parcial | EP01:146-149 | `email_sender.py:85,109`; `alterar-senha/page.tsx:108-159` | Campos e toggle OK; texto da tela diverge do literal do épico. |
+| US-03-RNF1 | Senha protegida (hash); e-mail em até 2 min | Parcial | EP01:153-154 | `service_usuario.py:168`; `route_admin.py:133-136` | Hash OK; envio síncrono sem fila/retry — falha de SMTP só logada. |
+| US-03-AC7 | "Esqueci minha senha" funciona como alternativa | Implementado | EP01:169 | `route_auth.py:121-145`; `esqueci-senha/page.tsx:18-25` | Invalida tokens antigos, gera novo, resposta genérica. |
+| US-05-RN1 | Logout voluntário; redireciona ao login | Parcial | EP01:181,183 | `route_usuarios.py:238-252`; `AuthContext.tsx:40-43` | Invalidação em memória (frágil); redirect depende do middleware. |
+| US-05-RN2 | Expiração automática por inatividade configurável (admin) | Ausente | EP01:182 | `jwt_handler.py:5,19`; `model_sessao.py:5-13` | Exp absoluto hardcoded; `Sessao` não usado no fluxo de auth. |
+| US-05-RV1 | Sessão expirada → login c/ "Sua sessão expirou..." | Implementado | EP01:188 | `api.ts:34-38`; `login/page.tsx:35-39,227-233` | Texto exato exibido via `returnTo`. |
+| US-05-RI1 | "Sair" sempre visível; logout imediato; "voltar" não retorna | Parcial | EP01:192-194 | `middleware.ts:39-43`; `AuthContext.tsx:40-43` | Logout imediato OK; visibilidade do "Sair" não verificada. |
+
+### EP-02 — Gestão de Usuários (US-07, US-08, US-09)
+
+| ID / US | Requisito (épico) | Status | Evid. épico | Evid. código | Observação |
+|---|---|---|---|---|---|
+| US-07-RN1 | Apenas admin cadastra professores | Parcial | EP02:33,58 | `route_admin.py:87-88` (sem decorators); `middleware.ts:47` | Backend público; restrição só no frontend. |
+| US-07-RN2 | Professor recebe perfil "Professor" no cadastro | Divergente | EP02:34 | `service_usuario.py:29` (role=ALUNO fixo); `service_professor.ts:28-47` | Backend grava ALUNO; frontend faz POST+PUT (não atômico). |
+| US-07-RN3 | Link de convite por e-mail | Implementado | EP02:35,65 | `route_admin.py:130-136`; `email_sender.py:18-29` | Convite gerado/enviado. |
+| US-07-RN4 | Matrícula e e-mail únicos | Implementado | EP02:37,42-43 | `model_usuario.py:16,18`; `route_admin.py:123-128` | Unique + checagem 409 na criação. |
+| US-07-RV1 | Nome/matrícula/e-mail obrigatórios; e-mail institucional | Implementado | EP02:41-43 | `route_admin.py:117-121`; `FormularioProfessor.tsx:24-26` | Exige `@iesb.edu.br`. |
+| US-07-RV2 | Mensagens específicas de matrícula/e-mail duplicado | Divergente | EP02:44-45 | `route_admin.py:128`; `FormularioProfessor.tsx:60-74` | Backend retorna genérico; frontend marca ambos os campos. |
+| US-07-RI1 | Formulário com Nome/Matrícula/E-mail | Implementado | EP02:49 | `FormularioProfessor.tsx:135-174` | Três campos presentes. |
+| US-07-RI2 | Confirmação + opção cadastrar outro/voltar | Parcial | EP02:50 | `FormularioProfessor.tsx:117-120` | Toast + redirect; sem "cadastrar outro". |
+| US-07-AC4 | Professor cria senha e acessa | Implementado | EP02:65 | `route_admin.py:284-365`; `service_usuario.py:156-186` | Coberto por `test_primeiro_acesso.py`. |
+| US-08-RN1 | Apenas admin cadastra alunos | Parcial | EP02:77,105 | `route_admin.py:87-88`; `middleware.ts:47` | Mesmo endpoint sem auth backend. |
+| US-08-RN2 | Aluno recebe perfil "Aluno" | Implementado | EP02:78 | `service_usuario.py:29-30` | role=ALUNO, status=ATIVO. |
+| US-08-RN3 | Link de convite por e-mail | Divergente | EP02:79,93,112 | `route_admin.py:130-136`; `service_aluno.ts:24-46`; `FormularioAluno.tsx:24-32` | Convite funciona; frontend gera "senha temporária" inútil (backend ignora). |
+| US-08-RN4 | Matrícula e e-mail únicos | Implementado | EP02:80,85-86 | `model_usuario.py:16,18`; `route_admin.py:123-128` | Igual US-07-RN4. |
+| US-08-RV1 | E-mail com formato válido (institucional) | Divergente | EP02:86,43 | `FormularioAluno.tsx:34-36`; `route_admin.py:120` | Form de aluno não exige `@iesb.edu.br`; backend exige → inconsistência. |
+| US-08-RV2 | Mensagens específicas de duplicidade | Divergente | EP02:87-88 | `route_admin.py:128`; `FormularioAluno.tsx:113-127` | Genérico; fallback marca ambos. |
+| US-08-RI1 | Formulário com Nome/Matrícula/E-mail | Implementado | EP02:92 | `FormularioAluno.tsx:137-176` | Presentes. |
+| US-08-RI2 | Confirmação + opção cadastrar outro/voltar | Parcial | EP02:94 | `FormularioAluno.tsx:107-110` | Toast + redirect; sem "cadastrar outro". |
+| US-08-RI3 | Listagem com busca (acima) e paginação (abaixo) | Parcial | EP02:95,113 | `alunos/page.tsx:211-217,228-234,89-92` | UI correta, mas opera só no cliente. |
+| US-08-RNF1 | Paginação **server-side** | Divergente | EP02:100,113 | `service_aluno.ts:9-18`; `alunos/page.tsx:89-92`; `route_admin.py:46-69` | Backend suporta, frontend não usa; traz todos e fatia no cliente. |
+| US-08-RNF2 | Busca server-side por nome/matrícula/**e-mail** | Divergente | EP02:101,114 | `alunos/page.tsx:76-85`; `service_usuario.py:126-142` | Frontend filtra em memória; backend não filtra por e-mail. |
+| US-08-AC3 | Aluno listado com status ativo | Implementado | EP02:111 | `service_usuario.py:30`; `alunos/page.tsx:145-157` | Badge de status. |
+| US-09-RN1 | Editar nome e e-mail de qualquer usuário | Parcial | EP02:126,157,152 | `route_admin.py:198-241`; `service_usuario.py:99-112` | Funciona, mas sem auth backend e sobrescreve matrícula/role/status. |
+| US-09-RN2 | Matrícula imutável após cadastro | Parcial | EP02:127,159 | `FormularioAluno.tsx:153`; `service_usuario.py:105` | Bloqueio só no frontend; backend grava qualquer matrícula. |
+| US-09-RN3 | Desativar usuário (impede login) | Implementado | EP02:128,160 | `route_admin.py:141-169`; `service_usuario.py:88-96` | status=INATIVO bloqueia novos logins. |
+| US-09-RN4 | Desativação não exclui histórico (soft delete) | Implementado | EP02:129 | `service_usuario.py:88-96` | Só altera status. |
+| US-09-RN5 | Reativar usuário | Implementado | EP02:130,161 | `route_admin.py:245-282`; `service_usuario.py:115-123` | Botão Reativar p/ desativados. |
+| US-09-RV1 | E-mail editado único c/ mensagem específica | Ausente | EP02:134,158 | `route_admin.py:198-241`; `service_usuario.py:99-112` | Sem checagem; IntegrityError → 500, não 409. |
+| US-09-RV2 | Desativar com sessão ativa → encerra a sessão | Ausente | EP02:136,148,160 | `service_usuario.py:88-96`; `auth_decorators.py:31-51` | JWT não invalidado; sem reconsulta de status. |
+| US-09-RV3 | Admin não desativa a própria conta | Ausente | EP02:162 | `route_admin.py:141-169`; `service_usuario.py:88-96` | Sem verificação; endpoint nem identifica solicitante. |
+| US-09-RI1 | Linha com Editar/Desativar/Reativar | Implementado | EP02:140 | `alunos/page.tsx:158-196`; `professores/page.tsx:170-208` | Presente. |
+| US-09-RI2 | Confirmação de desativar com texto específico | Implementado | EP02:141 | `alunos/page.tsx:258-262` | Texto idêntico ao épico. |
+| US-09-RI3 | Desativados identificados visualmente | Implementado | EP02:142 | `alunos/page.tsx:145-157` | Badge distinto. |
+| US-09-RI4 | Edição pré-preenchida | Implementado | EP02:143 | `editarAluno/page.tsx:7-25`; `FormularioAluno.tsx:38-53` | Dados via query params (frágil/expõe na URL). |
+| US-09-AC2 | E-mail duplicado na edição rejeitado | Ausente | EP02:158 | `route_admin.py:198-241` | Ver US-09-RV1 (500 em vez de 409). |
+
+### EP-03 — Gestão de Matérias e Turmas v1.4 (US-10, US-10b, US-11, US-12, US-13, US-14)
+
+| ID / US | Requisito (épico) | Status | Evid. épico | Evid. código | Observação |
+|---|---|---|---|---|---|
+| US-10-RN1 | Apenas admin cadastra matéria | Implementado | EP03:33 | `route_admin.py:405-407` (`@apenas_admins` OK) | `apenas_admins` compara 'ADMIN' (funciona). |
+| US-10-RN2 | Matéria independente; código único + nome | Implementado | EP03:34-35 | `model_materia.py:14-16`; `service_materia.py:78-90` | Código unique/index. |
+| US-10-RV1 | Código único c/ mensagem específica | Implementado | EP03:39 | `route_admin.py:420-425` | Mensagem idêntica ao épico. |
+| US-10-RV2 | Nome obrigatório | Implementado | EP03:40 | `route_admin.py:416-417`; `FormularioMateria.tsx:42-44` | Mensagem de erro backend textualmente incorreta, mas regra funciona. |
+| US-10-RI1 | Form Código/Nome; status "Ativa"; busca | Implementado | EP03:44-46 | `FormularioMateria.tsx:114-139`; `materias/page.tsx:100-108` | Busca client-side. |
+| US-10-CA | Critérios de aceite US-10 | Implementado | EP03:58-60 | `route_admin.py:405-430` | Cobertos. |
+| US-10b-RN1 | Editar nome; código imutável | Divergente | EP03:72 | `service_materia.py:93-105`; `route_admin.py:436-454` | Bloqueio só no frontend; backend sobrescreve código. |
+| US-10b-RN2 | Desativação preserva histórico; reativar | Implementado | EP03:73-74 | `service_materia.py:131-132`; `service_materia.ts:93-101` | Soft delete via status. |
+| US-10b-RN3 | Bloquear desativação com vínculos (US-12)/ofertas (US-13) | Divergente | EP03:75,102 | `service_materia.py:115-129` | Baseado no modelo v1.3 + `llm_id` (fora do escopo); entidades v1.4 inexistentes. |
+| US-10b-RV1 | Nome não vazio; código bloqueado | Parcial | EP03:79-80 | `FormularioMateria.tsx:42-44,128-137`; `route_admin.py:442` | Backend não trava imutabilidade do código. |
+| US-10b-RV2 | Mensagem específica ao bloquear desativação | Divergente | EP03:81 | `route_admin.py:470-478`; `materias/page.tsx:142-159` | Textos genéricos; lógica v1.3. |
+| US-10b-RI1 | Listagem c/ ações; confirmação; badge | Parcial | EP03:85-87 | `materias/page.tsx:205-238,279-339,186-198` | Frase principal de confirmação OK; complemento diverge. |
+| US-10b-CA | Critérios de aceite US-10b | Divergente | EP03:100-106 | `service_materia.py:93-134` | Código mutável; bloqueio sobre modelo v1.3. |
+| US-11-RN1 | Apenas admin cadastra turma | Implementado | EP03:118 | `route_turmas.py:72-75` (`@apenas_admins`) | Protegido. |
+| US-11-RN2 | Turma independente; código único, semestre, turno | Implementado | EP03:119-120 | `model_turma.py:14-16`; `service_turma.py:64-78` | Código unique/index. |
+| US-11-RN3 | Turma fechada: acesso automático às ofertas (US-13) | Ausente | EP03:121 | `service_vinculos.py:10-26` | Sem entidade de oferta nem propagação de acesso. |
+| US-11-RV1 | Código único c/ mensagem | Implementado | EP03:125 | `route_turmas.py:90-95`; `FormularioTurma.tsx:72-74` | Mensagem quase idêntica. |
+| US-11-RV2 | Semestre obrigatório (ex 2026.1) | Implementado | EP03:126 | `route_turmas.py:84-85`; `utils/turno.ts:26` | Front valida formato; back valida presença. |
+| US-11-RV3 | Turno obrigatório (Manhã/Tarde/Noite) | Divergente | EP03:127 | `route_turmas.py:87-88`; `utils/turno.ts:4-14` | Backend só aceita Matutino/Vespertino/Noturno. |
+| US-11-RI1 | Form Código/Semestre/Turno; status; busca/filtros | Implementado | EP03:131-133 | `FormularioTurma.tsx:40-66`; `turmas/page.tsx:282-311`; `service_turma.py:44-61` | Filtros server-side. |
+| US-11-CA | Critérios de aceite US-11 | Implementado | EP03:145-147 | `route_turmas.py:72-100` | Cobertos. |
+| US-12-RN1 | Vínculo professor↔matéria (entidade MateriaProfessor) | Ausente | EP03:158-162 | Inexistente (grep 0 fora de docs) | Só `ProfessorTurmaMateria` (v1.3). |
+| US-12-RN2 | Vínculo é pré-requisito da oferta (US-13) | Ausente | EP03:163 | `service_vinculos.py:96-114` | Cria tripla direta sem pré-requisito. |
+| US-12-RV1 | Não duplicar vínculo; mensagem específica | Ausente | EP03:168 | — | Sem rota/serviço/mensagem. |
+| US-12-RV2 | Não remover vínculo com ofertas ativas; confirmação | Ausente | EP03:169-170 | `route_vinculos.py:279` (só arquivos) | Sem remoção de vínculo prof↔matéria. |
+| US-12-RI1 | Seção "Vínculos"; busca prof/matéria | Ausente | EP03:174-175 | `service_vinculos.ts:32-40` (só GET) | Sem UI. |
+| US-12-CA | Critérios de aceite US-12 | Ausente | EP03:185-190 | — | Toda a US-12 v1.4 ausente. |
+| US-13-RN1 | Oferta (Prof+Matéria) a turma (MateriaProfessorTurma) | Divergente | EP03:200-203 | `model_professor_turma_materia.py:3-12`; `route_vinculos.py:162-192` | Tripla v1.3 cobre conceito, mas sem pré-requisito; rota com `@apenas_professores` quebrado. |
+| US-13-RN2 | Oferta requer vínculo MateriaProfessor existente | Ausente | EP03:204 | `service_vinculos.py:96-114` | Pré-requisito inexistente. |
+| US-13-RN3 | Criar oferta concede acesso; remover retira (histórico) | Ausente | EP03:208-209 | — | Sem propagação nem DELETE de oferta. |
+| US-13-RV1 | Não duplicar oferta; mensagem; confirmação | Divergente | EP03:213-214 | `service_vinculos.py:107-109`; `route_vinculos.py:186-187` | Checa duplicidade, mas mensagem "Vínculo já existe."; sem remoção. |
+| US-13-RI1 | Tela de turma c/ seção "Ofertas" | Ausente | EP03:218-220 | — | Sem página de detalhe de turma. |
+| US-13-CA | Critérios de aceite US-13 | Ausente | EP03:230-235 | — | Maioria ausente. |
+| US-14-RN1 | Apenas admin matricula/desmatricula | Divergente | EP03:247 | `route_vinculos.py:15-18` (`#@apenas_alunos`) | Restrição comentada → qualquer autenticado matricula. |
+| US-14-RN2 | Matrícula → acesso automático às ofertas; multi-turma | Parcial | EP03:248-249 | `service_vinculos.py:10-26`; `model_aluno_turma.py:9-10` | Multimatrícula OK; acesso automático ausente. |
+| US-14-RN3 | Desmatrícula retira acesso; só aluno ativo | Ausente | EP03:250-251 | `route_vinculos.py` (sem DELETE alunos_turmas) | Sem desmatrícula; sem checagem de aluno ativo. |
+| US-14-RV1 | Não duplicar matrícula; mensagem específica | Divergente | EP03:255 | `service_vinculos.py:20-22`; `route_vinculos.py:37-38` | Mensagem "Vínculo já existe." (diverge). |
+| US-14-RV2 | Desmatrícula pede confirmação | Ausente | EP03:256 | — | Sem fluxo. |
+| US-14-RI1 | Seção "Alunos" na turma; busca; confirmação | Ausente | EP03:260-262 | `service_vinculos.ts:8-16` (só GET) | Sem UI. |
+| US-14-CA | Critérios de aceite US-14 | Parcial | EP03:272-276 | `service_vinculos.py:10-26` | Só matrícula básica/duplicidade. |
+
+### EP-06 — Chat Educacional (US-22, US-23, US-24, US-25)
+
+| ID / US | Requisito (épico) | Status | Evid. épico | Evid. código | Observação |
+|---|---|---|---|---|---|
+| US-22-RN1 | Acesso só a matérias matriculadas | Parcial | EP06:32 | `service_data.py:16-33`; `validacao_emit.py:26-52`; `event_handler.py:48-60` | Dropdown filtra; socket **não valida matrícula** (só UUID). |
+| US-22-RN2 | Sessão por matéria; histórico próprio | Parcial | EP06:33-34 | `registrar_chat.py:5-23`; `event_handler.py:81,118` | Chat por matéria; `sessao_id=None` sempre. |
+| US-22-RN3 | IA usa só material indexado da matéria (RAG restrito) | Divergente | EP06:35 | `busca_semantica.py:9-32,57` | RAG restrito implementado, mas **quebrado** (`asyncio.to_thread` bug, l.57). |
+| US-22-RV1 | Matéria sem material → aviso específico | Ausente | EP06:39 | `event_handler.py:65-68` (comentado); `busca_semantica.py:55` | Fluxo segue à LLM com contexto vazio. |
+| US-22-RV2 | Aluno sem matrícula → tela informativa | Divergente | EP06:40 | `chat/page.tsx:188-195`; `service_data.py:33`; `route_data.py:7-17` | Tela dispara corretamente; só o texto diverge. |
+| US-22-RI1 | Direto ao chat, sem tela intermediária | Implementado | EP06:44,67 | `middleware.ts:49`; `chat/page.tsx` | Sem etapa de seleção. |
+| US-22-RI2 | Dropdown pré-preenchido (1ª em ordem alfabética) | Divergente | EP06:45,68 | `Header.tsx:45-65`; `page.tsx:44-48`; `service_data.py:22-33` | Sem ordenação alfabética. |
+| US-22-RI3 | 4 cartões de boas-vindas **sem ação ao clicar** | Divergente | EP06:47-51,69 | `NoMessageField.tsx:19-31`; `page.tsx:170-175` | Cartões têm `onClick` (injeta prompt). Contradição interna do épico (l.47 vs l.69). |
+| US-22-RI4 | Sidebar c/ logo, "Novo Chat", chats recentes (título+matéria) | Implementado | EP06:52,70 | `Aside.tsx:43-80`; `layout.tsx:33-48` | Limita a 5 recentes. |
+| US-22-RI5 | Campo de digitação pronto após carregamento | Implementado | EP06:53 | `TextArea.tsx:26-37`; `page.tsx:177-184` | Disponível imediatamente. |
+| US-23-RN1 | IA responde só com base no material; não inventa | Parcial | EP06:84-87 | `prompt_builder.py:5-19`; `event_handler.py:60-101` | Só instrução de prompt; sem gate de embasamento. |
+| US-23-RN2 | Recupera trechos relevantes (top-k) | Divergente | EP06:85 | `busca_semantica.py:14-32,57` | top_k=5 codificado, mas quebrado (l.57). |
+| US-23-RN3 | Sem trecho relevante → não inventar | Ausente | EP06:87,121 | `event_handler.py:65-68` (comentado) | Segue à LLM. |
+| US-23-RN4 | IA responde no idioma da pergunta | Divergente | EP06:88 | `prompt_builder.py:8` | Força português. |
+| US-23-RN5 | Fallback automático entre provedores de IA | Ausente | EP06:89,126 | `gerar_resposta.py:10-43`; `event_handler.py:93-114` | Só Ollama. (Conflito documental c/ visao.md.) |
+| US-23-RV1 | Pergunta vazia bloqueada; botão desabilitado | Parcial | EP06:93,100,122 | `TextArea.tsx:14-17,35`; `validacao_emit.py:35` | Envio bloqueado, mas botão não fica visualmente desabilitado com campo vazio. |
+| US-23-RV2 | Limite 1.000 chars + contador + aviso | Ausente | EP06:94,99,123 | `TextArea.tsx:26-37`; `model_mensagem.py:14` | Sem maxLength/contador; modelo aceita 3200. |
+| US-23-RV3 | Mensagem de indisponibilidade | Ausente | EP06:95,127 | `event_handler.py:112-114`; `chat/page.tsx:92-97` | Só `console.error`. |
+| US-23-RI1 | Botão desabilitado enquanto IA processa | Implementado | EP06:101,124 | `chat/page.tsx:135,89,95`; `TextArea.tsx:29,35` | `podeEnviarMensagem`. |
+| US-23-RI2 | Indicador "digitando..." | Parcial | EP06:102,125 | `chat/page.tsx:33,54-90`; `ErrorField.tsx:8-21` | Estados de socket; sem indicador textual dedicado. |
+| US-23-RI3 | Resposta em Markdown (sem texto bruto) | Implementado | EP06:103,125 | `MessageField.tsx:3,59` | `ReactMarkdown`. |
+| US-23-RI4 | Formato de conversa (balões) | Implementado | EP06:104 | `MessageField.tsx:54-61` | Classes user/LLM. |
+| US-23-RNF2 | Não enviar dados pessoais à IA | Implementado | EP06:109 | `prompt_builder.py:1-19`; `event_handler.py:101` | Prompt só com matéria/contexto/histórico/pergunta. |
+| US-23-RNF3 | Rastreabilidade da resposta aos trechos | Ausente | EP06:110 | `event_handler.py:116-118`; `model_mensagem.py:6-18` | Sem vínculo a chunks/fontes. |
+| US-24-RN1 | Histórico da sessão visível | Implementado | EP06:139,166 | `MessageField.tsx:18-65`; `chat/page.tsx:74-77` | Todas as mensagens renderizadas. |
+| US-24-RN2 | IA considera contexto anterior + trechos | Parcial | EP06:140,167 | `chat/page.tsx:115,121`; `event_handler.py:87-101` | Funciona, sem janela de 10. |
+| US-24-RN3 | Janela de contexto = últimas 10 trocas | Ausente | EP06:141,168 | `chat/page.tsx:115`; `event_handler.py:87-90`; `service_mensagem.py:17-33` | Envia histórico inteiro; `buscar_ultimas_n_mensagens` não usado. |
+| US-24-RI2 | Mensagens user/IA diferenciadas | Implementado | EP06:152,169 | `MessageField.tsx:55-58` | OK. |
+| US-24-RN5 | Reabrir chat → nova conversa | Implementado | EP06:143 | `chat/page.tsx:148-158`; `Aside.tsx:39-42` | `deleteAllMessages` no mount. |
+| US-25-RN1 | Detecção de baixa confiança (não inventar) | Ausente | EP06:181-191,214 | `event_handler.py:65-68` (comentado); `MCP_pipeline.py:14-17` (não usado) | Nenhum dos 4 critérios avaliado. |
+| US-25-RN2 | Não revelar detalhes técnicos | Divergente | EP06:182 | `event_handler.py:45,63,114,121` | `str(e)` trafega ao cliente (front não exibe). |
+| US-25-RV1 | Resposta nunca enviada sem embasamento | Ausente | EP06:195 | `event_handler.py:104-111` | Sempre streama, sem gate. |
+| US-25-RI1 | Mensagem "Não encontrei uma resposta..." | Ausente | EP06:200-201 | — | Sem detecção/mensagem. |
+| US-25-RNF1 | Detecção dentro de 30s | Não verificável | EP06:205 | N/A | Sem detecção + depende de ambiente. |
+
+### EP-09 — Gestão do Modelo de IA (US-38, US-38.1)
+
+| ID / US | Requisito (épico) | Status | Evid. épico | Evid. código | Observação |
+|---|---|---|---|---|---|
+| US-38-RN1 | Scraping da biblioteca oficial do Ollama | Ausente | EP09:32 | `scraping_handler.py:38` (genérico) | Sem referência a ollama.com/library. |
+| US-38-RN2 | Consultar API local p/ instalados (/api/tags) | Ausente | EP09:33 | `gerar_resposta.py:22` (só /api/generate) | Sem /api/tags. |
+| US-38-RN3 | Estados Instalado/Disponível | Ausente | EP09:34 | `catalogoLLM/page.tsx:4-7` (vazio) | Tela vazia. |
+| US-38-RN4 | Pull via API antes de ativar | Ausente | EP09:35 | — (sem /api/pull) | Sem download. |
+| US-38-RN5 | Progresso de download em tempo real | Ausente | EP09:36 | — | Sem download. |
+| US-38-RN6 | Modal de confirmação ao ativar | Ausente | EP09:37,55-59 | `catalogoLLM/page.tsx:4-7` | Sem UI/modal. |
+| US-38-RN7 | Definir modelo como ativo | Parcial | EP09:38 | `service_llm.py:5-24`; `route_llm.py:10-30` | Lógica existe; sem rota POST nem UI. |
+| US-38-RN8 | Modelo ativo persistido e usado na geração | Parcial | EP09:39 | `model_llm.py:8-13`; `event_handler.py:93-94`; `service_llm.py:64` | Depende da **coluna `status` sem migration** (GAP-01). |
+| US-38-RN9 | Um ativo por vez; troca sem reprocessar | Parcial | EP09:40 | `service_llm.py:20-21` | Unicidade em app; só via serviço. |
+| US-38-RN10 | Configuração global | Implementado | EP09:41 | `service_llm.py:55-65`; `event_handler.py:93`; `test_modelo_ativo.py:120-143` | Modelo global. |
+| US-38-RV1 | Mensagem de falha de scraping | Ausente | EP09:45 | — | Sem scraping/mensagem. |
+| US-38-RV2 | Mensagem "Ollama não encontrado" | Ausente | EP09:46 | `gerar_resposta.py:33` | Erro genérico no chat. |
+| US-38-RV3 | Mensagem de falha de download | Ausente | EP09:47 | — | Sem download. |
+| US-38-RV4 | Não ativar modelo não instalado | Divergente | EP09:48 | `service_llm.py:16` | Só verifica registro em banco, não instalação. |
+| US-38-RI1 | Lista c/ nome, tamanho, estado | Ausente | EP09:52 | `catalogoLLM/page.tsx:4-7`; `Aside.tsx:16` | Menu existe; tela vazia; sem "tamanho". |
+| US-38-RI2 | Botões Ativar/Fazer Download | Ausente | EP09:53 | — | Tela vazia. |
+| US-38-RI3 | Modelo ativo destacado (badge) | Ausente | EP09:54 | `route_llm.py:10-30` (não consumido) | Sem UI. |
+| US-38-RI4 | Modal de ativação (textos exatos) | Ausente | EP09:55-59 | — | Sem componente. |
+| US-38-RI5 | Barra de progresso c/ cancelar | Ausente | EP09:60 | — | Sem UI. |
+| US-38-RI6 | Confirmação "Modelo [nome] ativado" | Ausente | EP09:61 | `route_llm.py` (só GET) | Sem rota/UI. |
+| US-38-RNF1 | Progresso em tempo real (SSE/polling) | Ausente | EP09:65 | `event_handler.py:107-111` (só chat) | Sem download. |
+| US-38-RNF2 | Troca não interrompe sessões em andamento | Divergente | EP09:66 | `event_handler.py:93`; `test_modelo_ativo.py:87-117` | Resolve por mensagem; novo modelo já na próxima mensagem da sessão. |
+| US-38-RNF3 | Cache de 1h da lista | Ausente | EP09:67 | — | Sem listagem/cache. |
+| US-38-PR1 | Apenas admin autenticado acessa | Divergente | EP09:71; RBAC:211 | `route_llm.py:1-30` | Sem auth backend; padrão existe mas é omitido. |
+| US-38-CA | Critérios de aceite US-38 | Ausente | EP09:76-87 | `service_llm.py`; `event_handler.py:93` | Só persistência/uso parciais (comprometidos por GAP-01). |
+| US-38.1-RN1 | Migration add_status_column_to_llm.py | Ausente | EP09:97-99,110 | migrations llm (3 arquivos) | **Migration não existe**; coluna só no model. |
+| US-38.1-RN2 | Model com coluna status | Implementado | EP09:99 | `model_llm.py:8-13` | Enum NOT NULL default 'desativada'. |
+| US-38.1-RN3 | Service ativação/desativação | Implementado | EP09:99,105 | `service_llm.py:5-65` | Garante unicidade do ativo. |
+| US-38.1-RN4 | Testes do service | Parcial | EP09:99 | `tests/migration/test_llm.py`; `test_modelo_ativo.py` | Mockam db (não tocam schema); chave stale 'model_id'. |
+| US-38.1-RN5 | Coluna NOT NULL/default persistida após restart | Divergente | EP09:103-106,110-113 | `model_llm.py:8-13` | CA marcados [v], mas migration inexistente. |
+
+---
+
+## Gaps por Épico
+
+### EP-01 — Autenticação
+
+**GAP-01-A (US-01/GAP-02) — Decorators de perfil quebrados** · **Severidade: Crítica**
+- **Épico exige:** controle de acesso por perfil coerente (EP01:35-38; RBAC relacionado).
+- **Código faz:** JWT grava `role` como nome (`'PROFESSOR'/'ALUNO'`, `route_usuarios.py:129,192` via `model_usuario.py:38`), mas `apenas_professores` (`auth_decorators.py:76`) e `apenas_alunos` (`:87`) comparam contra `'1'/'2'/'3'` → nunca casam.
+- **Impacto:** toda rota protegida por esses decorators (`route_arquivos.py:43,121,197,256,279,335,414`; `route_vinculos.py:47,91,141,164,196,251,281`) retorna **403 incondicional**; professores/alunos não acessam suas funcionalidades.
+- **Arquivos:** `auth_decorators.py:76,87`; `jwt_handler.py:5,16-21`; `model_usuario.py:5-8,38`.
+- **Ref. complementar:** rbac.md (redirecionamento/403 por perfil).
+- **Recomendação:** padronizar o claim `role` (nome em maiúsculas) em geradores e decorators; corrigir `apenas_professores`→'PROFESSOR', `apenas_alunos`→'ALUNO'.
+- **Testes:** unitários dos decorators com roles reais; integração de rota de professor/aluno com token correto (200) e incorreto (403).
+
+**GAP-01-B (US-05/GAP-01) — Sessão sem expiração por inatividade configurável** · **Alta**
+- **Épico exige:** expiração por inatividade configurável pelo admin (EP01:61,182,207).
+- **Código faz:** JWT com exp **absoluta** de 60 min hardcoded (`jwt_handler.py:5,19`); `model_sessao.py` não usado.
+- **Impacto:** critério "sessão inativa expira" não atendido; tempo não administrável.
+- **Recomendação:** sliding expiration / `last_activity` em `Sessao` + valor configurável.
+- **Testes:** expiração por inatividade; renovação por atividade; leitura do valor configurável.
+
+**GAP-01-C (US-03/GAP-03) — Criação de senha não inicia sessão / rota duplicada** · **Alta**
+- **Épico exige:** após criar senha, link invalidado e usuário acessa a home do perfil (EP01:132,167).
+- **Código faz:** frontend usa `/auth/invite/set-password` (`route_auth.py:55-118`) que **não** inicia sessão → redireciona a `/login`. O endpoint que inicia sessão (`route_admin.py:284-365`) não é chamado e redireciona a `/painel/{role_slug}` (rota inexistente).
+- **Recomendação:** unificar em um endpoint que valide confirmação, defina senha, invalide token, emita JWT e retorne destino coerente com `homeForRole`.
+- **Testes:** e2e convite→criar senha→sessão iniciada→home do perfil.
+
+**GAP-01-D (US-02/GAP-04) — Mensagens do Google divergentes** · **Média**
+- **Código faz:** backend retorna 404 com texto diferente (`route_usuarios.py:122-124`); frontend só mapeia 401/403 (`service_aluno.ts:127-130`).
+- **Recomendação:** mapear 404→mensagem de contatar admin; padronizar mensagem genérica de falha do Google.
+
+**GAP-01-E (US-05/GAP-05) — Invalidação de token em memória** · **Média**
+- **Código faz:** `TOKENS_INVALIDADOS` é set em memória do processo (`auth_decorators.py:6,23`).
+- **Impacto:** logout não é globalmente efetivo (multi-worker/restart); token "encerrado" segue aceito por outros workers.
+- **Recomendação:** denylist persistida (Redis/DB) ou sessões server-side.
+
+**GAP-01-F (US-03/GAP-06) — Confirmação de senha só no cliente** · **Média**
+- **Código faz:** endpoint usado não valida `passwordConfirmation` (`route_auth.py:96-98`); mensagem literal ausente.
+- **Recomendação:** validar confirmação no servidor com a mensagem do épico (consolidar com GAP-01-C).
+
+**GAP-01-G (US-01/GAP-07) — Label "Matrícula"** · **Baixa**
+- **Código faz:** `login/page.tsx:128-139` usa "Matrícula" em vez de "Matrícula institucional".
+
+### EP-02 — Gestão de Usuários
+
+**GAP-02-A (US-07/08/09) — Endpoints de gestão de usuários sem autenticação** · **Crítica**
+- **Épico exige:** apenas admin autenticado cadastra/edita/desativa/reativa (EP02:33,77,126-128,58,105,152).
+- **Código faz:** `GET /usuarios/all`, `POST /usuarios/criar`, `GET/PUT /usuarios/<id>`, `DELETE /usuarios/delete/<id>`, `PATCH /usuarios/<id>/reativar` **sem** `@token_obrigatorio`/`@apenas_admins` (`route_admin.py:22,87,141,173,198,245`). Em `route_admin.py` só as rotas `/materia` têm decorators.
+- **Impacto:** qualquer pessoa (até não autenticada) lista/cria/edita/desativa/reativa usuários via API.
+- **Ref. complementar:** rbac.md (gestão de usuários = admin total; 403 p/ outros). `GET /alunos/professors` (`route_usuarios.py:256-257`) já é protegido — evidencia o padrão omitido.
+- **Recomendação:** aplicar `@token_obrigatorio`+`@apenas_admins` em todas as rotas `/usuarios/*`.
+- **Testes:** por endpoint — sem token 401, perfil errado 403, admin 2xx.
+
+**GAP-02-B (US-09) — Desativar não encerra sessão ativa** · **Crítica**
+- **Código faz:** `desativar_aluno` (`service_usuario.py:88-96`) não invalida o JWT; `token_obrigatorio` não reconsulta status.
+- **Impacto:** usuário desativado mantém acesso a rotas protegidas por ~60 min.
+- **Recomendação:** invalidar tokens ativos ao desativar OU reconsultar status no `token_obrigatorio`.
+
+**GAP-02-C (US-09) — Auto-desativação não bloqueada** · **Crítica**
+- **Código faz:** sem comparação solicitante×alvo (`route_admin.py:141-169`); endpoint sem `@token_obrigatorio` (sem `g.usuario_id`).
+- **Recomendação:** após aplicar auth (GAP-02-A), bloquear `g.usuario_id == alvo` (403).
+
+**GAP-02-D (US-08) — Paginação/busca não server-side** · **Alta**
+- **Código faz:** frontend chama `/usuarios/all` sem `page/limit/filtros` e pagina/filtra no cliente (`service_aluno.ts:9-18`; `alunos/page.tsx:40-92`); backend suporta paginação/nome/matrícula mas **não** e-mail (`service_usuario.py:126-142`).
+- **Recomendação:** integrar paginação/busca server-side; adicionar filtro por e-mail.
+
+**GAP-02-E (US-09) — Matrícula alterável no backend** · **Alta**
+- **Código faz:** bloqueio só no frontend; `alterar_aluno_por_id` grava qualquer matrícula (`service_usuario.py:105`).
+- **Recomendação:** ignorar/rejeitar alteração de matrícula no PUT.
+
+**GAP-02-F (US-09) — E-mail duplicado na edição → 500** · **Alta**
+- **Código faz:** PUT não valida unicidade nem trata `IntegrityError` (`route_admin.py:198-241`); frontend espera 409 que nunca chega.
+- **Recomendação:** verificar e-mail de outro usuário e retornar 409 com mensagem do épico.
+
+**GAP-02-G (US-07/08/09) — Mensagens de duplicidade genéricas** · **Média**
+- **Código faz:** backend retorna "Email ou matrícula já cadastrados." (`route_admin.py:128`); frontend marca ambos os campos.
+- **Recomendação:** checar matrícula e e-mail separadamente com textos do épico.
+
+**GAP-02-H (US-08) — Validação de e-mail institucional inconsistente** · **Média**
+- **Código faz:** `FormularioAluno` não exige `@iesb.edu.br` (`:34-36`), mas backend exige (`route_admin.py:120`).
+
+**GAP-02-I (US-07) — Atribuição de role não atômica** · **Média**
+- **Código faz:** `criar_usuario` fixa ALUNO (`:29`); frontend faz POST+PUT (`service_professor.ts:28-47`). Se o PUT falhar, fica ALUNO.
+- **Recomendação:** permitir role no `/usuarios/criar` (operação atômica).
+
+**GAP-02-J (US-07/08) — Sem opção "cadastrar outro"** · **Baixa**
+- **Código faz:** toast + redirect automático (`FormularioAluno.tsx:107-110`).
+
+**GAP-02-K (US-09) — Modelagem role/status no mesmo enum** · **Média**
+- **Código faz:** `role` e `status` compartilham `RoleEnum` (`model_usuario.py:5-10,21`) → permite estados inválidos (ex: status=PROFESSOR).
+- **Recomendação:** separar `RoleEnum` e `StatusEnum`.
+
+### EP-03 — Gestão de Matérias e Turmas
+
+**G1 (US-12) — Entidade MateriaProfessor inexistente** · **Crítica**
+- **Épico exige:** vínculo professor↔matéria (sem turma) como pré-requisito de oferta (EP03:158-163).
+- **Código faz:** não há model/tabela/serviço/rota; usa `ProfessorTurmaMateria` (v1.3). Grep 0 fora de docs; migration `54bc685a0304` cria só tabelas v1.3.
+- **Recomendação:** criar entidade `MateriaProfessor` (par único) + serviço/rotas admin; refatorar oferta (US-13).
+
+**G2 (US-13) — Oferta MateriaProfessorTurma não conforme** · **Crítica**
+- **Código faz:** cria tripla direta sem pré-requisito; sem DELETE de oferta; mensagem genérica; sem propagação de acesso ao chat; rota com `@apenas_professores` quebrado.
+- **Recomendação:** referenciar `MateriaProfessor`+turma; validar pré-requisito; DELETE com confirmação; conceder/remover acesso; `@apenas_admins`.
+
+**G3 (US-14) — Matrícula sem proteção de admin** · **Crítica**
+- **Código faz:** `POST /alunos_turmas` com `@apenas_alunos` **comentado** (`route_vinculos.py:15-18`); sem checagem de aluno ativo; sem DELETE de desmatrícula.
+- **Impacto:** qualquer autenticado matricula alunos.
+- **Recomendação:** `@apenas_admins`; validar status ATIVO; criar DELETE de desmatrícula.
+
+**G4 (US-12/13/14) — Sem tela de detalhe de turma** · **Crítica**
+- **Código faz:** não há página de detalhe; `service_vinculos.ts` só tem GET.
+- **Impacto:** admin não tem UI para ofertas, matrícula ou vínculos.
+- **Recomendação:** criar página de detalhe com seções Ofertas/Alunos/Vínculos + funções POST/DELETE.
+
+**G5 (US-10b) — Código da matéria mutável no backend** · **Alta**
+- **Código faz:** `updateSubject` sobrescreve `materia.codigo` (`service_materia.py:100`); bloqueio só no frontend.
+
+**G6 (US-10b) — Bloqueio de desativação sobre modelo v1.3** · **Alta**
+- **Código faz:** bloqueia por `llm_id` (fora do escopo) e `TurmaMateria` ativa; mensagens genéricas.
+- **Recomendação:** checar `MateriaProfessor`/`MateriaProfessorTurma` ativos; mensagem exata (EP03:81).
+
+**G7 (US-12/13) — Decorator `apenas_professores` quebrado** · **Alta**
+- **Código faz:** rotas de `turmas_materias`/`professores_turmas_materias` usam `@apenas_professores` (`auth_decorators.py:76`, compara '1'/'2') → **403 universal**.
+- **Impacto:** rotas inacessíveis (falha funcional); mesmo corrigido restringiria a professor, não a admin.
+- **Recomendação:** corrigir decorator e aplicar `@apenas_admins`.
+
+**G8 (US-11) — Vocabulário de turno divergente** · **Média**
+- **Código faz:** backend só aceita Matutino/Vespertino/Noturno (`route_turmas.py:87,117`); front traduz.
+
+**G9 (US-10b) — Textos de confirmação/bloqueio divergentes** · **Média**
+- **Código faz:** complemento da confirmação e mensagem de bloqueio divergem do épico (`materias/page.tsx:314-338`).
+
+**G10 (US-10/11) — RNF de tempo (≤5s)** · **Baixa**
+- **Código faz:** INSERT simples sem instrumentação. Não verificável estaticamente.
+
+### EP-06 — Chat Educacional
+
+**GAP-06-A (US-25) — Detecção de baixa confiança ausente** · **Crítica**
+- **Épico exige:** IA não inventa resposta sem embasamento (4 critérios; EP06:181-191,214).
+- **Código faz:** bloco de contexto vazio comentado (`event_handler.py:65-68`); `MCPPipeline.valid_stream` nunca usado; resposta sempre gerada.
+- **Impacto:** IA pode alucinar — compromete o núcleo do produto.
+- **Recomendação:** gate de confiança (threshold/contexto vazio) antes da LLM + persistir trecho-fonte.
+
+**GAP-06-B (US-22/23) — RAG quebrado em runtime** · **Crítica**
+- **Código faz:** `busca_semantica.py:57` → `await asyncio.to_thread(buscar_no_vector_db(query,arquivos_ids))` chama a função e passa o **resultado** como callable → `TypeError` sempre que há material.
+- **Recomendação:** `chunks = await asyncio.to_thread(buscar_no_vector_db, query, arquivos_ids)`.
+
+**GAP-06-C (US-24) — Janela de 10 trocas ausente** · **Alta**
+- **Código faz:** envia histórico inteiro (`chat/page.tsx:115`; `event_handler.py:87-90`); `buscar_ultimas_n_mensagens(n=20)` não usado.
+- **Recomendação:** recortar últimas 10 trocas no backend.
+
+**GAP-06-D (US-23) — Limite de 1.000 chars/contador ausente** · **Alta**
+- **Código faz:** `TextArea` sem maxLength/contador; modelo aceita 3200 (`model_mensagem.py:14`).
+- **Recomendação:** `maxLength=1000` + contador + validação backend.
+
+**GAP-06-E (US-23) — Sem fallback/mensagem de indisponibilidade** · **Alta**
+- **Código faz:** só Ollama; falha → `console.error` (`chat/page.tsx:92-97`).
+- **Ref. complementar:** visao.md afirma NÃO haver fallback (resolver divergência primeiro).
+
+**GAP-06-F (US-22) — Acesso ao chat sem validação de matrícula no backend** · **Alta**
+- **Código faz:** `validacao_emit.py:32` só valida UUID; socket processa qualquer `materia_id`.
+- **Impacto:** aluno consulta matéria não matriculada.
+- **Recomendação:** validar `(id_usuario, materia_id)` via `AlunoTurma→TurmaMateria` no handler.
+
+**GAP-06-G (US-22) — Cartões com ação ao clicar** · **Média**
+- **Código faz:** `onClick` injeta prompt (`NoMessageField.tsx:20-30`). Contradição interna do épico (l.47 vs l.69).
+
+**GAP-06-H (US-22) — Sem aviso de matéria sem material** · **Média**
+- **Código faz:** segue à LLM com contexto vazio (`event_handler.py:65-68` comentado).
+
+**GAP-06-I (US-22) — Dropdown sem ordenação alfabética** · **Média**
+- **Código faz:** ordem de iteração (`service_data.py:22-33`); front usa `materias[0]` sem sort.
+
+**GAP-06-J (US-23) — Indicador "digitando..." ausente** · **Média**
+
+**GAP-06-K (US-23) — Botão não desabilita com campo vazio** · **Baixa**
+
+**GAP-06-L (US-23) — Idioma forçado em português** · **Baixa** (`prompt_builder.py:8`)
+
+**GAP-06-M (US-23) — Sem rastreabilidade de fontes** · **Baixa**
+
+**GAP-06-N (US-22) — Texto da tela "sem matrícula" divergente** · **Baixa**
+
+### EP-09 — Gestão do Modelo de IA
+
+**GAP-09-A (US-38.1) — Migration da coluna `status` inexistente** · **Crítica**
+- **Épico exige:** migration que adiciona `status` ENUM NOT NULL DEFAULT 'desativada' (CA marcados [v]; EP09:97-99,110-113).
+- **Código faz:** nenhuma migration adiciona a coluna; `63125fcdb5a0` é no-op (`pass`); coluna só no model (`model_llm.py:8-13`). Deploy usa `flask db upgrade` (`entrypoint.sh:20`).
+- **Impacto:** em produção/CI a tabela `llm` não terá `status` → `ativar_modelo`/`getActiveModel` e o chat falham.
+- **Recomendação:** criar migration Alembic alinhada ao model; validar contra banco real.
+
+**GAP-09-B (US-38) — Catálogo dinâmico ausente** · **Crítica**
+- **Código faz:** sem scraping de ollama.com/library nem `/api/tags`; só `/api/generate`; sem cache.
+- **Recomendação:** serviço de catálogo (scraping c/ cache 1h + `/api/tags`) protegido por admin.
+
+**GAP-09-C (US-38) — Download (pull) ausente** · **Crítica**
+- **Código faz:** sem `/api/pull` nem progresso.
+- **Recomendação:** `/api/pull` com streaming de progresso (SSE/Socket.IO), cancelamento e falha sem trocar o ativo.
+
+**GAP-09-D (US-38) — UI do catálogo ausente** · **Alta**
+- **Código faz:** `catalogoLLM/page.tsx:4-7` vazio; só item de menu (`Aside.tsx:16`).
+- **Recomendação:** implementar tela (lista, badge, modal com textos exatos, progresso, toasts).
+
+**GAP-09-E (US-38) — Sem rota/UI de ativação** · **Alta**
+- **Código faz:** `service_llm.ativar_modelo` existe, mas `route_llm.py` só tem `GET /llm/active`.
+- **Recomendação:** `POST /llm/<id>/activate` protegido por admin.
+
+**GAP-09-F (US-38) — `route_llm` sem autenticação** · **Alta**
+- **Código faz:** sem `@token_obrigatorio`/`@apenas_admins`; `/llm/active` público.
+- **Recomendação:** aplicar decorators existentes.
+
+**GAP-09-G (US-38) — Sem mensagens de erro específicas / valida só registro** · **Média**
+
+**GAP-09-H (US-38.1) — Divergência de schema (PK model_id vs id+nome)** · **Baixa**
+
+---
+
+## Divergências Documentais
+
+> Inconsistências entre os épicos e RBAC/sitemap/visão (ou entre épicos). **Não** são tratadas como falha de código.
+
+1. **Destino do aluno após login.** EP-01 US-01 (l.38) diz "tela de seleção de matéria"; EP-06 US-22 (l.44,67) e sitemap 4.1 dizem que **não há tela intermediária** (vai direto ao chat). Divergência épico×épico (e épico×sitemap). O código segue EP-06.
+2. **Fallback entre provedores de IA.** EP-06 US-23 (l.89,126) exige fallback automático; visao.md RN-02 (l.258) afirma que **não há fallback** (Ollama indisponível = erro); EP-09 corrobora modelo único. Contradição direta de regra de negócio.
+3. **Modelo de associação US-12.** EP-03 v1.4: US-12 = professor↔matéria (`MateriaProfessor`). rbac.md 3.4 e sitemap 2.4.4 ainda descrevem US-12 como "Associação turma+matéria (TURMA_MATERIA)". Documentos de apoio desatualizados frente ao épico.
+4. **Modelo de associação US-13.** EP-03 v1.4: US-13 = oferta `MateriaProfessorTurma` (depende de US-12). rbac.md 3.5/sitemap 2.4.5 modelam como `PROFESSOR_TURMA_MATERIA` direto, sem pré-requisito. Divergência de modelo e nomenclatura.
+5. **Numeração de telas do sitemap (2.4.4/2.4.5).** O sitemap mapeia US-12/US-13 a telas cujas descrições não correspondem ao conteúdo atual dessas US (refatoração v1.4 não propagada).
+6. **Local de gestão das associações.** EP-03 US-12 (l.174) coloca os vínculos na tela de professores/matérias; sitemap 2.4.3 concentra tudo no "Detalhe da turma".
+7. **Numeração US-14.** Colisão: US-14 é "Matrícula de aluno" (EP-03) e também "Envio de material" (EP-04, conforme sitemap 3.2.2 e diagrama). Como não há arquivo EP-04, a numeração conflita.
+8. **Mensagem de escalonamento.** EP-06 US-25 (l.200): "Não encontrei uma resposta nos materiais disponíveis."; visao.md 9.1 acrescenta "Sua dúvida foi enviada ao professor." Copy divergente.
+9. **Escalonamento ao professor (EP-07).** rbac/sitemap/visão descrevem o módulo (US-26 a US-29), mas **não há arquivo de épico EP-07**; EP-06 só referencia marginalmente.
+10. **Numeração das US de escalonamento.** Dentro do próprio sitemap, US-27 do EP-07 aparece com dois significados conflitantes.
+11. **Módulos sem épico (EP-04/EP-05/EP-08).** Materiais, ingestão e dashboard são detalhados/numerados em rbac/sitemap/visão (US-15, US-17, US-30 a US-34) mas **não têm arquivo de épico**.
+12. **Login por matrícula vs matrícula OU e-mail.** EP-01 US-01 restringe à matrícula; visao.md (RN-07/RN-08/RF-01) e sitemap 1.1 permitem matrícula **ou** e-mail.
+13. **Escopo do professor.** EP-03 introduz vínculo professor↔matéria desacoplado de turma (US-12); rbac.md modela escopo do professor só por "turmas+matérias".
+14. **US-11b inexistente.** Sitemap 2.4.1/2.4.2 referenciam "EP-03/US-11b" (editar/desativar turma) que não existe no épico (há US-10b para matéria, sem equivalente para turma).
+15. **US-06b e US-35 inexistentes no EP-02.** Sitemap 2.2.1/2.2.2 (US-06b cadastro de admin) e fluxo 5.5 (US-35 perfil do usuário) referenciam US ausentes do arquivo do EP-02.
+16. **US-36 (tema) atribuída ao EP-01.** Sitemap fluxo 5.6 referencia "EP-01/US-36" (seletor de tema), inexistente no épico; EP-01 também menciona US-06 ("Esqueci minha senha") sem especificá-la.
+17. **EP-09 — CA marcados como concluídos.** US-38.1 marca os critérios como [v] ("Migration criada e aplicada"), mas a migration não existe (divergência status declarado × código).
+18. **EP-09 — schema e nomes de arquivos.** Épico descreve PK `model_id` + `status` (sem `nome`); código usa PK `id` + `nome` + `status`. Nomes citados (`llm.py`, `tests/test_llm.py`) divergem dos reais (`model_llm.py`, `application/tests/migration/test_llm.py`).
+
+---
+
+## Funcionalidades dos Épicos Ausentes
+
+> Apenas itens **especificados nos épicos** sem evidência relevante no código.
+
+**EP-01:**
+- Expiração de sessão por **inatividade configurável** pelo admin (US-05-RN2).
+
+**EP-02:**
+- Validação server-side de **e-mail único na edição** com mensagem (US-09-RV1/AC2).
+- **Encerramento da sessão ativa ao desativar** usuário (US-09-RV2).
+- Bloqueio de **auto-desativação** do admin (US-09-RV3).
+
+**EP-03 (núcleo do v1.4):**
+- Entidade/fluxo **MateriaProfessor** — vínculo professor↔matéria (US-12 inteira).
+- **Pré-requisito** de vínculo para oferta (US-13-RN2).
+- **Acesso automático** do aluno às ofertas da turma (US-11-RN3, US-13-RN3, US-14-RN2 parcial).
+- **Desmatrícula** de aluno (US-14-RN3/RV2).
+- **Telas/seções** de Ofertas, Alunos e Vínculos no detalhe de turma (US-12-RI1, US-13-RI1, US-14-RI1).
+
+**EP-06:**
+- **Detecção de baixa confiança** e não-invenção (US-25 inteira; US-23-RN3).
+- **Janela de contexto de 10 trocas** (US-24-RN3).
+- **Limite de 1.000 caracteres** + contador + aviso (US-23-RV2).
+- **Fallback de provedor** + mensagem de indisponibilidade (US-23-RN5/RV3).
+- **Aviso de matéria sem material** (US-22-RV1).
+- **Rastreabilidade** da resposta aos trechos (US-23-RNF3).
+
+**EP-09:**
+- **Scraping da biblioteca Ollama** + cache 1h (US-38-RN1/RNF3).
+- **Consulta de instalados** (`/api/tags`) e estados Instalado/Disponível (US-38-RN2/RN3).
+- **Download (pull)** + progresso em tempo real (US-38-RN4/RN5/RNF1).
+- **Modal de confirmação**, botões e **toda a UI do catálogo** (US-38-RN6/RI1-RI6).
+- **Migration da coluna `status`** na tabela `llm` (US-38.1-RN1).
+- Mensagens de erro específicas (US-38-RV1/RV2/RV3).
+
+---
+
+## Funcionalidades Implementadas Fora do Escopo dos Épicos
+
+> Código encontrado que **não** corresponde a nenhum dos 5 épicos com arquivo. Mapeado, quando possível, ao módulo de apoio relacionado (EP-04/EP-07/EP-08).
+
+| Funcionalidade | Arquivos (principais) | Doc relacionado |
+|---|---|---|
+| **Upload e ingestão de materiais (arquivos)** — upload, validação de extensões, metadados, extração (Docling/Whisper), indexação no ChromaDB | `route_arquivos.py:41`; `service_arquivo.py:23,41,68,92`; `libs/docling_handler.py`, `whisper_handler.py`; `service_arquivo.ts:15` | EP-04 (RF-14–19); visao 5.2; sitemap 3.2.2; rbac 3.7 |
+| **Upload via links externos (scraping Selenium)** | `route_arquivos.py:119`; `service_arquivo.py:188`; `libs/scraping_handler.py`; `service_link.ts:5` | EP-04 (RF-15/RF-23) |
+| **Upload via texto direto** | `route_arquivos.py:195`; `service_arquivo.py:255`; `service_arquivo.ts:45` | EP-04 (RF-14) |
+| **Gestão de arquivos (obter/download/editar/excluir/listar)** | `route_arquivos.py:254,277,333,412,448`; `service_arquivo.py:318-512` | EP-04 (RF-17–19); rbac 3.7; sitemap 3.2.1 |
+| **Vínculo Arquivo-Turma-Matéria** (associação material↔turma+matéria) | `route_vinculos.py:217,249,279`; `service_vinculos.py` (arquivo_turma_materia); `service_vinculos.ts:44,54` | EP-04; rbac 3.7 |
+| **Página de upload de fontes (professor)** | `professor/pages/upload/page.tsx:14`; `SourceUpload.tsx`; `professor/components/Aside/Aside.tsx:50` | EP-04 (RF-14); sitemap 3.2.2; visao 9.2 |
+| **Detalhe de matéria do professor (listagem de fontes)** | `professor/pages/materias/materia/[materiaId]/page.tsx:18`; `professor/pages/materias/page.tsx` | EP-04 (RF-19); sitemap 3.2.1; rbac 3.7 |
+| **Dashboard analítico do professor (estatísticas/KPIs)** — dados mock/estáticos | `professor/pages/estatisticas/page.tsx:12`; `CardPequeno/CardMedio/BarraDeProgresso`; `Aside.tsx:56` | EP-08 (RF-41–45); sitemap 3.4; rbac 3.10; visao 9.5 |
+| **Home do professor com KPIs e ações rápidas** (mock) | `professor/page.tsx:9`; `CardPequeno.tsx` | EP-08; sitemap 3.1/3.4 |
+| **Detalhe de turma do professor com estatísticas** (mock) | `professor/pages/turmas/turma/[turmaId]/page.tsx:18` | EP-08; sitemap 3.4; rbac 3.10 |
+| **Chat Tutor para o professor** | `professor/page.tsx:70`; `professor/components/Aside/Aside.tsx:62` | Nenhum (EP-06 restringe chat ao aluno; rbac diz que professor não interage com o chat) |
+| **Endpoint genérico `/data` (matérias/turmas do usuário)** | `route_data.py:7,19`; `service_data.py:5,16`; `service_data.ts:6,16` | Parcialmente EP-06/US-22; `/data` não descrito em épico |
+| **Migração de metadados do ChromaDB (`arquivo_id`)** | `route_arquivos.py:18`; `service_arquivo.py:514` | Nenhum (tarefa técnica) |
+| **Criação de vínculos turma-matéria / professor-turma-matéria pelo professor** | `route_vinculos.py:89,162` (`@apenas_professores`), `:15` (`@apenas_alunos` comentado) | EP-03 atribui essas ações ao Admin; rbac 3.4/3.5/3.6 |
+
+---
+
+## Cobertura de Testes por Épico
+
+### EP-01 — Autenticação
+- **Testes encontrados:** `tests/routes/test_login_google.py` (US-02: 400/401/403/404/200, não cria usuário); `tests/routes/test_primeiro_acesso.py` (US-03: criar usuário, e-mail de convite, validação de token 200/410, recriar_senha, força de senha, token used). *(Obs.: mocks usam `role='3'`/`'RoleEnum.ALUNO'`, divergente do `to_dict` real → não detectam o mismatch de role do GAP-01-A.)*
+- **Requisitos sem teste:** login matrícula/senha (sucesso/401 genérico/403 inativo/400); `/encerrar-sessao` e invalidação; expiração; decorators `apenas_professores`/`apenas_alunos` (GAP-01-A); endpoint realmente usado `/auth/invite/set-password`; todo o frontend.
+- **Testes recomendados:** `test_login` (200+cookie, 401 genérico, 403 inativo, 400); decorators de RBAC com nomes reais; `/auth/invite/set-password`; logout/expiração; frontend (mensagens, mapeamento de erros Google, redirect por perfil, middleware).
+
+### EP-02 — Gestão de Usuários
+- **Testes encontrados:** `tests/routes/test_primeiro_acesso.py` cobre criação + convite + primeiro acesso (US-07/08). **Nenhum teste de frontend** (Glob só retorna node_modules).
+- **Requisitos sem teste:** autorização dos endpoints (GAP-02-A), encerramento ao desativar (GAP-02-B), auto-desativação (GAP-02-C), paginação/busca server-side (GAP-02-D), matrícula imutável backend (GAP-02-E), e-mail único na edição (GAP-02-F), edição/desativação/reativação, mensagens de duplicidade, role atômica, modelagem role/status.
+- **Testes recomendados:** autorização por endpoint (401/403/2xx), auto-desativação (403), invalidação ao desativar, PUT (nome/e-mail, matrícula imutável, 409 e-mail), paginação/filtro server-side; RTL dos formulários e do modal.
+
+### EP-03 — Matérias e Turmas
+- **Testes encontrados:** **nenhum** cobrindo o EP-03 (existentes tratam de login/primeiro acesso/sockets/LLM).
+- **Requisitos sem teste:** **todos** (US-10, US-10b, US-11, US-12, US-13, US-14).
+- **Testes recomendados:** CRUD matéria (código duplicado/imutável, desativação/bloqueio), CRUD turma (semestre/turno, duplicado), RBAC das rotas de associação/oferta/matrícula (regressão do decorator quebrado e da matrícula sem proteção), vínculo professor↔matéria, oferta, matrícula/desmatrícula; formulários no frontend.
+
+### EP-06 — Chat Educacional
+- **Testes encontrados:** `tests/socket/` — `test_disparar_emit.py`, `test_registrar_chat.py`, `test_registrar_mensagem.py`, `test_validacao_emit.py` (*sem asserts, usa chave errada `id_materia`*), `test_modelo_ativo.py`. Nenhum teste de frontend.
+- **Requisitos sem teste:** RAG e bug `busca_semantica:57`, detecção de baixa confiança (US-25), janela de 10 trocas, limite 1000/botão vazio, fallback/indisponibilidade, restrição backend de matrícula, ordenação do dropdown, cartões sem ação, markdown, aviso de matéria sem material, idioma, rastreabilidade.
+- **Testes recomendados:** gate de baixa confiança; integração de `busca_semantica` (com/sem arquivos, cobrindo a correção do `asyncio.to_thread`); recorte de 10 trocas; contador/maxLength; validação backend de `materia_id` não matriculado; fallback + mensagem; ordenação/pré-seleção; cartões sem ação; converter `test_validacao_emit.py` em asserts e corrigir a chave.
+
+### EP-09 — Gestão do Modelo de IA
+- **Testes encontrados:** `tests/migration/test_llm.py` (+ duplicado em `backend/tests/migration/test_llm.py`) — mockam `LLM`/`db` (não tocam schema; chave stale `model_id`); `tests/socket/test_modelo_ativo.py` e `tests/routes/test_llm_route.py` (DB real, mas `conftest.py` só ajusta PYTHONPATH, sem `create_all`).
+- **Requisitos sem teste:** **a migration real da coluna `status`** (crítico), scraping/cache/`/api/tags`, pull/progresso, UI do catálogo, mensagens de erro, "não ativar não instalado", autorização admin.
+- **Testes recomendados:** migration aplicada em banco real (coluna NOT NULL/default); rota POST de ativação (único ativo, 404/401/403); serviço de catálogo (scraping mockado + cache + `/api/tags`); pull (progresso/cancelamento/falha); frontend (lista/badge/modal/progresso); corrigir mocks `model_id`→`id`.
+
+---
+
+## Observações finais
+
+- **Padrão sistêmico de segurança:** regras de autorização frequentemente residem **apenas no frontend** (`middleware.ts`, validação de formulários), com o backend aberto ou com decorators inconsistentes. Recomenda-se uma revisão transversal de autorização no backend (aplicar `@token_obrigatorio`/`@apenas_admins` de forma consistente e padronizar o claim `role`).
+- **Modelo de dados EP-03 desatualizado:** o código permanece no modelo v1.3 enquanto o épico (e o diagrama) já estão no v1.4; rbac/sitemap/visão também refletem o modelo antigo — recomenda-se alinhar épico↔documentos↔código antes de implementar US-12/13/14.
+- **EP-09 não funcional em produção:** mesmo a parte implementada (modelo ativo) depende de uma coluna sem migration — prioridade de correção imediata.
+- **EP-06 com núcleo quebrado:** a correção do bug `asyncio.to_thread` e a implementação do gate de baixa confiança são pré-condições para a proposta de valor do produto ("IA sem alucinação").

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -35,13 +35,18 @@ WORKDIR /app
 COPY --from=build /app/package.json ./
 COPY --from=build /app/next.config.ts ./
 COPY --from=build /app/public ./public
-COPY --from=build /app/.next ./.next
+# .next pertence ao usuário 'node' para permitir escrita do cache em runtime (ISR).
+COPY --from=build --chown=node:node /app/.next ./.next
 
 # Copia a pasta node_modules COMPLETA e já funcional do estágio de build
 COPY --from=build /app/node_modules ./node_modules
 
 # Expondo a porta que a aplicação irá rodar (Next.js padrão é 3000)
 EXPOSE 3000
+
+# Executa como usuário não-root (a imagem node:20-alpine já provê o usuário 'node').
+# Mitiga o risco de um processo comprometido ter privilégios de root no container.
+USER node
 
 # Comando para iniciar a aplicação
 CMD ["./node_modules/.bin/next", "start", "-H", "0.0.0.0"]

--- a/frontend/app/(pages)/admin/components/FormularioAluno/FormularioAluno.tsx
+++ b/frontend/app/(pages)/admin/components/FormularioAluno/FormularioAluno.tsx
@@ -31,8 +31,8 @@ function gerarSenhaTemporaria(): string {
     return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
 }
 
-function emailValido(email: string): boolean {
-    return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+function emailInstitucionalValido(email: string): boolean {
+    return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email) && email.endsWith("@iesb.edu.br");
 }
 
 export default function FormularioAluno({
@@ -58,7 +58,8 @@ export default function FormularioAluno({
         if (!nome.trim()) e.nome = "Informe o nome completo.";
         if (!matricula.trim()) e.matricula = "Informe a matrícula.";
         if (!email.trim()) e.email = "Informe o e-mail.";
-        else if (!emailValido(email)) e.email = "E-mail inválido.";
+        else if (!emailInstitucionalValido(email.trim()))
+            e.email = "Informe um e-mail institucional válido (@iesb.edu.br).";
         return e;
     }
 
@@ -88,7 +89,7 @@ export default function FormularioAluno({
                 return;
             }
             if (resultado.status === 409) {
-                setErros({ email: "E-mail já cadastrado." });
+                setErros({ email: "Este e-mail já está em uso por outro usuário." });
                 return;
             }
             setErros({ geral: resultado.message });

--- a/frontend/app/(pages)/admin/components/FormularioAluno/FormularioAluno.tsx
+++ b/frontend/app/(pages)/admin/components/FormularioAluno/FormularioAluno.tsx
@@ -105,7 +105,7 @@ export default function FormularioAluno({
         setSubmitting(false);
 
         if (resultado.ok) {
-            addToast("Aluno cadastrado com sucesso.", "success");
+            addToast("Aluno cadastrado! Um link de convite foi enviado para o e-mail informado.", "success");
             router.push("/admin/pages/alunos");
             return;
         }
@@ -114,14 +114,14 @@ export default function FormularioAluno({
             const msg = resultado.message.toLowerCase();
             const next: CampoErros = {};
             if (msg.includes("matrícula") || msg.includes("matricula")) {
-                next.matricula = "Matrícula já cadastrada.";
+                next.matricula = "Esta matrícula já está em uso por outro usuário.";
             }
             if (msg.includes("email") || msg.includes("e-mail")) {
-                next.email = "E-mail já cadastrado.";
+                next.email = "Este e-mail já está em uso por outro usuário.";
             }
             if (!next.matricula && !next.email) {
-                next.matricula = "Matrícula já cadastrada.";
-                next.email = "E-mail já cadastrado.";
+                next.matricula = "Esta matrícula já está em uso por outro usuário.";
+                next.email = "Este e-mail já está em uso por outro usuário.";
             }
             setErros(next);
             return;

--- a/frontend/app/(pages)/admin/components/FormularioProfessor/FormularioProfessor.tsx
+++ b/frontend/app/(pages)/admin/components/FormularioProfessor/FormularioProfessor.tsx
@@ -61,14 +61,14 @@ export default function FormularioProfessor({
         const msg = message.toLowerCase();
         const next: CampoErros = {};
         if (msg.includes("matrícula") || msg.includes("matricula")) {
-            next.matricula = "Matrícula já cadastrada.";
+            next.matricula = "Esta matrícula já está em uso por outro usuário.";
         }
         if (msg.includes("email") || msg.includes("e-mail")) {
-            next.email = "E-mail já cadastrado.";
+            next.email = "Este e-mail já está em uso por outro usuário.";
         }
         if (!next.matricula && !next.email) {
-            next.matricula = "Matrícula já cadastrada.";
-            next.email = "E-mail já cadastrado.";
+            next.matricula = "Esta matrícula já está em uso por outro usuário.";
+            next.email = "Este e-mail já está em uso por outro usuário.";
         }
         return next;
     }

--- a/frontend/app/(pages)/admin/components/Header/Header.tsx
+++ b/frontend/app/(pages)/admin/components/Header/Header.tsx
@@ -4,7 +4,6 @@ import styles from "./Header.module.css"
 import { Bell, Menu, Home } from "lucide-react";
 import { usePathname } from "next/navigation";
 import { useContext, useEffect, useState } from "react";
-import { useRouter } from "next/navigation";
 import { useAuth } from '@/utils/auth';
 import { LayoutContext } from '@/contexts/LayoutContext';
 import { Role } from '@/utils/roles';
@@ -28,7 +27,6 @@ const roleLabel: Record<string, string> = {
 export default function Header(){
     const { user } = useAuth();
     const pathname = usePathname();
-    const router = useRouter();
     const { setIsMenuAbertoMobile } = useContext(LayoutContext)!;
     const [caminho, setCaminho] = useState("");
 
@@ -48,9 +46,12 @@ export default function Header(){
         setCaminho(segments.at(-1) ? slugToLabel(segments.at(-1)!) : '');
     }, [pathname]);
 
-    const handleSair = () => {
-        router.push("/login");
-        logout();
+    const handleSair = async () => {
+        await logout();
+        // Redireciona com replace (recarrega e limpa o histórico) somente após o
+        // cookie de sessão ser removido, evitando que o middleware reenvie o
+        // usuário de volta à área autenticada (US-05-RN1).
+        window.location.replace("/login");
     };
 
     return(

--- a/frontend/app/(pages)/admin/pages/alunos/page.tsx
+++ b/frontend/app/(pages)/admin/pages/alunos/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Pencil, Trash2, RotateCw, Plus, AlertTriangle } from "lucide-react";
 import styles from "./page.module.css";
@@ -9,7 +9,7 @@ import Button from "../../../../components/Button/Button";
 import SearchInput from "../../../../components/SearchInput/SearchInput";
 import Pagination from "../../../../components/Pagination/Pagination";
 import Modal from "../../../../components/Modal/Modal";
-import { listarAlunos, desativarAluno, reativarAluno } from "../../../../services/service_aluno";
+import { listarAlunosPaginado, desativarAluno, reativarAluno } from "../../../../services/service_aluno";
 import { Status } from "@/utils/roles";
 import { useToast } from "@/contexts/ToastContext";
 
@@ -32,30 +32,42 @@ export default function Alunos() {
     const { addToast } = useToast();
     const [alunos, setAlunos] = useState<Aluno[]>([]);
     const [search, setSearch] = useState("");
+    const [debouncedSearch, setDebouncedSearch] = useState("");
     const [page, setPage] = useState(1);
     const [pageSize, setPageSize] = useState(8);
+    const [totalPages, setTotalPages] = useState(1);
     const [alunoParaDesativar, setAlunoParaDesativar] = useState<Aluno | null>(null);
     const tableAreaRef = useRef<HTMLDivElement>(null);
 
+    // Debounce da busca: evita uma requisição por tecla e volta para a 1ª página.
     useEffect(() => {
-        let cancelled = false;
-        (async () => {
-            const usuarios = await listarAlunos();
-            if (cancelled) return;
-            setAlunos(
-                usuarios.map((u) => ({
-                    id: u.id,
-                    nome: u.nome,
-                    matricula: u.matricula,
-                    email: u.email,
-                    status: u.status === Status.ATIVO ? "Ativo" : "Desativado",
-                }))
-            );
-        })();
-        return () => {
-            cancelled = true;
-        };
-    }, []);
+        const t = setTimeout(() => {
+            setDebouncedSearch(search);
+            setPage(1);
+        }, 300);
+        return () => clearTimeout(t);
+    }, [search]);
+
+    // Busca a página atual no servidor (paginação + filtro server-side — GAP-02-D).
+    const carregar = useCallback(async () => {
+        if (pageSize < 1) return;
+        const r = await listarAlunosPaginado(page, pageSize, debouncedSearch);
+        setAlunos(
+            r.usuarios.map((u) => ({
+                id: u.id,
+                nome: u.nome,
+                matricula: u.matricula,
+                email: u.email,
+                status: u.status === Status.ATIVO ? "Ativo" : "Desativado",
+            }))
+        );
+        setTotalPages(Math.max(1, r.pages));
+        if (r.pages >= 1 && page > r.pages) setPage(r.pages);
+    }, [page, pageSize, debouncedSearch]);
+
+    useEffect(() => {
+        carregar();
+    }, [carregar]);
 
     useLayoutEffect(() => {
         const el = tableAreaRef.current;
@@ -73,31 +85,8 @@ export default function Alunos() {
         return () => ro.disconnect();
     }, []);
 
-    const filteredAlunos = useMemo(() => {
-        const term = search.trim().toLowerCase();
-        if (!term) return alunos;
-        return alunos.filter(
-            (a) =>
-                a.nome.toLowerCase().includes(term) ||
-                a.matricula.toLowerCase().includes(term) ||
-                a.email.toLowerCase().includes(term)
-        );
-    }, [alunos, search]);
-
-    const totalPages = Math.max(1, Math.ceil(filteredAlunos.length / pageSize));
-    const currentPage = Math.min(page, totalPages);
-    const pagedAlunos = filteredAlunos.slice(
-        (currentPage - 1) * pageSize,
-        currentPage * pageSize
-    );
-
-    useEffect(() => {
-        if (page > totalPages) setPage(totalPages);
-    }, [page, totalPages]);
-
     function handleSearchChange(value: string) {
         setSearch(value);
-        setPage(1);
     }
 
     function handleEdit(aluno: Aluno) {
@@ -118,12 +107,8 @@ export default function Alunos() {
         if (!alunoParaDesativar) return;
         const resultado = await desativarAluno(alunoParaDesativar.id);
         if (resultado.ok) {
-            setAlunos((prev) =>
-                prev.map((a) =>
-                    a.id === alunoParaDesativar.id ? { ...a, status: "Desativado" } : a
-                )
-            );
             addToast("Aluno desativado.", "success");
+            carregar();
         }
         setAlunoParaDesativar(null);
     }
@@ -131,10 +116,8 @@ export default function Alunos() {
     async function handleReactivate(aluno: Aluno) {
         const resultado = await reativarAluno(aluno.id);
         if (resultado.ok) {
-            setAlunos((prev) =>
-                prev.map((a) => (a.id === aluno.id ? { ...a, status: "Ativo" } : a))
-            );
             addToast("Aluno reativado.", "success");
+            carregar();
         }
     }
 
@@ -219,7 +202,7 @@ export default function Alunos() {
             <div ref={tableAreaRef} className={styles.tableArea}>
                 <Table
                     columns={columns}
-                    data={pagedAlunos}
+                    data={alunos}
                     rowKey={(row) => row.id}
                     emptyMessage="Nenhum aluno encontrado."
                 />
@@ -227,7 +210,7 @@ export default function Alunos() {
 
             <div className={styles.paginationRow}>
                 <Pagination
-                    currentPage={currentPage}
+                    currentPage={page}
                     totalPages={totalPages}
                     onPageChange={setPage}
                 />

--- a/frontend/app/(pages)/alterar-senha/alterarSenha.module.css
+++ b/frontend/app/(pages)/alterar-senha/alterarSenha.module.css
@@ -46,6 +46,17 @@
     color: #4d9b8d;
 }
 
+.resetTag {
+    align-self: center;
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: #4d9b8d;
+    background-color: rgba(77, 155, 141, 0.1);
+    padding: 0.25rem 0.75rem;
+    border-radius: 999px;
+    margin-bottom: 0.25rem;
+}
+
 .welcomeTitle {
     font-size: 1.5rem;
     font-weight: 700;

--- a/frontend/app/(pages)/alterar-senha/page.tsx
+++ b/frontend/app/(pages)/alterar-senha/page.tsx
@@ -65,15 +65,20 @@ const [loading, setLoading] = useState<boolean>(false);
         e.preventDefault();
         setErrorMessage(null);
 
+        if (novaSenha !== confirmacaoSenha) {
+            setErrorMessage('As senhas não conferem. Por favor, digite novamente.');
+            return;
+        }
+
         if (!senhaValida) {
-            setErrorMessage('A senha não atende todos os requisitos.');
+            setErrorMessage('A senha não atende aos requisitos mínimos.');
             return;
         }
 
         setLoading(true);
 
         try {
-            const result = await criarSenha(token, novaSenha);
+            const result = await criarSenha(token, novaSenha, confirmacaoSenha);
 
             if (!result.ok) {
                 if (result.status === 410) {
@@ -82,7 +87,7 @@ const [loading, setLoading] = useState<boolean>(false);
                         'Este link já foi utilizado ou é inválido. Utilize a opção "Esqueci minha senha" para redefinir seu acesso.'
                     );
                 } else {
-                    setErrorMessage('Erro ao criar a senha. Tente novamente em instantes.');
+                    setErrorMessage(result.message || 'Erro ao criar a senha. Tente novamente em instantes.');
                 }
                 return;
             }

--- a/frontend/app/(pages)/alterar-senha/page.tsx
+++ b/frontend/app/(pages)/alterar-senha/page.tsx
@@ -9,6 +9,8 @@ import Button from '@/app/components/Button/Button';
 import Toast from '@/app/components/Toast/Toast';
 import TutorLogoIcon from '@/app/components/TutorLogoIcon';
 import { criarSenha } from '@/app/services/service_auth';
+import { useAuth } from '@/utils/auth';
+import { homeForRole } from '@/utils/roles';
 
 interface RegrasSenha {
     minCaracteres: boolean;
@@ -40,6 +42,10 @@ function IndicadorRegra({ valida, texto }: { valida: boolean; texto: string }) {
 function AlterarSenha() {
     const router = useRouter();
     const searchParams = useSearchParams();
+    const { refreshUser } = useAuth();
+
+    // Fluxo de redefinição (recuperação de senha) — o e-mail de reset inclui &reset=1.
+    const isReset = searchParams?.get('reset') === '1';
 
     const [token, setToken] = useState<string>('');
     const [novaSenha, setNovaSenha] = useState<string>('');
@@ -92,7 +98,9 @@ const [loading, setLoading] = useState<boolean>(false);
                 return;
             }
 
-            router.push('/login?senhaCriada=1');
+            // US-03-RN3: a sessão já foi iniciada (cookie); vai direto à home do perfil.
+            await refreshUser();
+            router.push(homeForRole(result.usuario?.role));
         } catch {
             setErrorMessage('Erro ao criar a senha. Tente novamente em instantes.');
         } finally {
@@ -109,6 +117,8 @@ const [loading, setLoading] = useState<boolean>(false);
                 <TutorLogoIcon size={28} color="#f97316" />
                 <span className={styles.brandName}>Tutor</span>
             </div>
+
+            {isReset && <span className={styles.resetTag}>Redefinir senha</span>}
 
             <h2 className={styles.welcomeTitle}>Defina sua senha</h2>
             <p className={styles.welcomeSubtitle}>

--- a/frontend/app/(pages)/chat/components/Header/Header.tsx
+++ b/frontend/app/(pages)/chat/components/Header/Header.tsx
@@ -4,7 +4,6 @@ import styles from "./Header.module.css"
 import { User, Bell, Menu } from "lucide-react";
 import { useAuth } from "@/utils/auth";
 import { useData } from "@/utils/data";
-import { useRouter } from "next/navigation";
 import { useContext } from "react";
 import { LayoutContext } from "@/contexts/LayoutContext";
 import HeaderUserIcon from "@/app/components/HeaderUserIcon/HeaderUserIcon";
@@ -19,7 +18,6 @@ interface HeaderInterface {
 export default function Header({ isSelectInactive, materiaName, onMateriaChange }: HeaderInterface) {
     const { user } = useAuth();
     const { materias } = useData();
-    const router = useRouter();
     const { setIsMenuAbertoMobile } = useContext(LayoutContext)!;
 
     const handleSelectChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
@@ -31,11 +29,14 @@ export default function Header({ isSelectInactive, materiaName, onMateriaChange 
     };
 
     
-    const handleSair = () => {
-        logout();
-        router.push("/login")
+    const handleSair = async () => {
+        await logout();
+        // Redireciona com replace (recarrega e limpa o histórico) somente após o
+        // cookie de sessão ser removido, evitando que o middleware reenvie o
+        // usuário de volta à área autenticada (US-05-RN1).
+        window.location.replace("/login");
     }
-    
+
 
     return (
         <section className={styles.headerConteiner}>

--- a/frontend/app/(pages)/chat/page.tsx
+++ b/frontend/app/(pages)/chat/page.tsx
@@ -12,6 +12,7 @@ import { useData } from "@/utils/data";
 import { useAuth } from "@/utils/auth";
 import styles from "./page.module.css"
 import socket from "../../../libs/socket";
+import { touchSessao } from "@/app/services/service_auth";
 
 type SocketEvento =
     | "processando"
@@ -96,6 +97,15 @@ export default function Chat() {
             console.error("[Socket erro]", data.erro);
         });
 
+        // Sessão inválida/expirada no socket → volta para o login.
+        const redirecionarParaLogin = () => {
+            window.location.href = "/login?returnTo=/chat";
+        };
+        socket.on("sessao_expirada", redirecionarParaLogin);
+        socket.on("connect_error", () => {
+            console.error("[Socket] falha ao conectar (sessão inválida?)");
+        });
+
         return () => {
             socket.off("processando");
             socket.off("buscando_arquivos");
@@ -104,6 +114,8 @@ export default function Chat() {
             socket.off("resposta_finalizada");
             socket.off("processo_completo");
             socket.off("erro");
+            socket.off("sessao_expirada", redirecionarParaLogin);
+            socket.off("connect_error");
             socket.disconnect();
         };
     }, []);
@@ -134,6 +146,10 @@ export default function Chat() {
         setText("");
         setPodeEnviarMensagem(false);
         llmBolhaCriada.current = false;
+
+        // Atividade real → renova a sessão HTTP (sliding), já que o socket não
+        // pode reescrever o cookie httponly.
+        touchSessao();
 
         socket.emit("mensagem_inicial", payload);
     };

--- a/frontend/app/(pages)/login/page.module.css
+++ b/frontend/app/(pages)/login/page.module.css
@@ -46,6 +46,19 @@
     color: #1a1a1a;
 }
 
+.formError {
+    width: 100%;
+    margin: 0.75rem 0 0 0;
+    padding: 0.625rem 0.875rem;
+    font-size: 0.875rem;
+    line-height: 1.4;
+    color: #b91c1c;
+    background-color: #fef2f2;
+    border: 1px solid #fecaca;
+    border-radius: 8px;
+    text-align: center;
+}
+
 .inputContainer {
     display: flex;
     flex-direction: row;

--- a/frontend/app/(pages)/login/page.tsx
+++ b/frontend/app/(pages)/login/page.tsx
@@ -44,6 +44,10 @@ function LoginContent() {
                 return "Sua conta está desativada. Entre em contato com o administrador da sua instituição para reativá-la.";
             case "invalid_credentials":
                 return "Matrícula ou senha incorretos. Verifique e tente novamente.";
+            case "google_not_linked":
+                return "Sua conta Google não está vinculada a nenhum usuário nesta plataforma. Entre em contato com o administrador.";
+            case "google_failure":
+                return "Não foi possível autenticar com o Google. Tente novamente ou use sua matrícula e senha.";
             default:
                 return "Erro ao realizar login. Tente novamente em instantes.";
         }
@@ -102,7 +106,7 @@ function LoginContent() {
         } catch (error) {
             console.error("Erro no login Google:", error);
             setInputsInvalid(true);
-            setErrorMessage("Erro ao tentar login com Google");
+            setErrorMessage(messageForError("google_failure"));
         } finally {
             setLoading(false);
         }
@@ -190,6 +194,12 @@ function LoginContent() {
 
             </form>
 
+            {errorMessage && (
+                <p className={styles.formError} role="alert">
+                    {errorMessage}
+                </p>
+            )}
+
             <Script
                 src="https://accounts.google.com/gsi/client"
                 strategy="lazyOnload"
@@ -215,14 +225,6 @@ function LoginContent() {
                     );
                 }}
             />
-
-            {errorMessage && (
-                <Toast
-                    message={errorMessage}
-                    type="error"
-                    onClose={() => setErrorMessage(null)}
-                />
-            )}
 
             {showSessionExpiredToast && !errorMessage && (
                 <Toast

--- a/frontend/app/(pages)/professor/components/Aside/Aside.tsx
+++ b/frontend/app/(pages)/professor/components/Aside/Aside.tsx
@@ -4,11 +4,18 @@ import { usePathname, useRouter } from 'next/navigation';
 import { House, Book, GraduationCap, FolderPlus, ChartColumn, MessageCircleMore, BookOpen, Settings, LogOut } from 'lucide-react';
 import AsideMainButton from '../../../../components/AsideMainButton/AsideMainButton';
 import Button from '../../../../components/Button/Button';
+import { logout } from '@/app/services/service_auth';
 import styles from './Aside.module.css';
 
 export default function Aside() {
     const pathname = usePathname();
     const router = useRouter();
+
+    const handleSair = async () => {
+        await logout();
+        // Redireciona após remover o cookie de sessão (US-05-RN1/RI1).
+        window.location.replace('/login');
+    };
 
     const getSelected = () => {
         if (pathname?.endsWith('/professor')) return 'home';
@@ -79,6 +86,7 @@ export default function Aside() {
                     icon={<LogOut size={16} />}
                     label="Sair"
                     fullWidth
+                    onClick={handleSair}
                 />
             </div>
         </div>

--- a/frontend/app/services/service_aluno.ts
+++ b/frontend/app/services/service_aluno.ts
@@ -17,6 +17,45 @@ export async function listarAlunos(): Promise<AlunoBackend[]> {
     }
 }
 
+export interface AlunosPaginados {
+    usuarios: AlunoBackend[];
+    page: number;
+    pages: number;
+    total: number;
+}
+
+/**
+ * Listagem de alunos paginada e filtrada no servidor (US-08-RNF1/RNF2 / GAP-02-D):
+ * a página é buscada sob demanda e a busca por nome/matrícula/e-mail é executada
+ * na base de dados.
+ */
+export async function listarAlunosPaginado(
+    page: number,
+    limit: number,
+    busca?: string
+): Promise<AlunosPaginados> {
+    try {
+        const response = await api.get(`admin/usuarios/all`, {
+            params: {
+                page,
+                limit,
+                role: Role.ALUNO,
+                ...(busca && busca.trim() ? { busca: busca.trim() } : {}),
+            },
+        });
+        const d = response.data ?? {};
+        return {
+            usuarios: d.usuarios ?? [],
+            page: d.pagination?.page ?? page,
+            pages: d.pagination?.pages ?? 1,
+            total: d.pagination?.total ?? 0,
+        };
+    } catch (error) {
+        console.error("Erro ao listar alunos:", error);
+        return { usuarios: [], page: 1, pages: 1, total: 0 };
+    }
+}
+
 export type CriarAlunoResultado =
     | { ok: true; aluno: InterfaceUsuario }
     | { ok: false; status: number; message: string };

--- a/frontend/app/services/service_aluno.ts
+++ b/frontend/app/services/service_aluno.ts
@@ -93,7 +93,12 @@ export async function reativarAluno(id: string): Promise<{ ok: boolean; message?
     }
 }
 
-export type LoginErrorCode = "invalid_credentials" | "deactivated" | "unknown";
+export type LoginErrorCode =
+    | "invalid_credentials"
+    | "deactivated"
+    | "google_not_linked"
+    | "google_failure"
+    | "unknown";
 
 export type LoginResultado =
     | { ok: true; aluno: InterfaceUsuario }
@@ -124,9 +129,9 @@ export async function loginAlunoGoogle(googleToken: string): Promise<LoginResult
         return { ok: true, aluno: response.data.aluno };
     } catch (error: any) {
         const status = error?.response?.status ?? 0;
-        if (status === 401) return { ok: false, error: "invalid_credentials" };
         if (status === 403) return { ok: false, error: "deactivated" };
+        if (status === 404) return { ok: false, error: "google_not_linked" };
         console.error("Erro login Google:", error);
-        return { ok: false, error: "unknown" };
+        return { ok: false, error: "google_failure" };
     }
 }

--- a/frontend/app/services/service_auth.ts
+++ b/frontend/app/services/service_auth.ts
@@ -49,6 +49,27 @@ export async function logout(): Promise<void> {
     }
 }
 
+/**
+ * Renova a sessão por atividade (sliding expiration). Usado pelo chat a cada
+ * envio de mensagem — como o WebSocket não pode reescrever o cookie httponly,
+ * esta chamada HTTP mantém a sessão viva enquanto o aluno conversa.
+ *
+ * Usa fetch direto (sem o interceptor/spinner global do axios) e é best-effort:
+ * a expiração efetiva é tratada pelo socket ("sessao_expirada") e pelo 401 das
+ * demais chamadas.
+ */
+export async function touchSessao(): Promise<void> {
+    const baseUrl = process.env.NEXT_PUBLIC_API_URL_RUNTIME ?? "";
+    try {
+        await fetch(`${baseUrl}/alunos/sessao/touch`, {
+            method: "POST",
+            credentials: "include",
+        });
+    } catch {
+        // silencioso — renovação é best-effort
+    }
+}
+
 export async function validarToken(token: string): Promise<ValidarTokenResultado> {
     try {
         const response = await api.get(`/auth/invite/validate/${encodeURIComponent(token)}`);
@@ -64,12 +85,13 @@ export async function validarToken(token: string): Promise<ValidarTokenResultado
 
 export async function criarSenha(
     token: string,
-    senha: string
+    senha: string,
+    confirmacao: string
 ): Promise<CriarSenhaResultado> {
     try {
         await api.post(
             "/auth/invite/set-password",
-            { token, senha },
+            { token, senha, confirmacao },
             {
                 headers: { "Content-Type": "application/json" },
                 withCredentials: true,

--- a/frontend/app/services/service_auth.ts
+++ b/frontend/app/services/service_auth.ts
@@ -18,7 +18,7 @@ export type ValidarTokenResultado =
     | { ok: false; status: number; message: string };
 
 export type CriarSenhaResultado =
-    | { ok: true }
+    | { ok: true; usuario: Usuario }
     | { ok: false; status: number; message: string };
     
 export async function solicitarRecuperacaoSenha(email: string): Promise<{ ok: boolean }> {
@@ -89,7 +89,7 @@ export async function criarSenha(
     confirmacao: string
 ): Promise<CriarSenhaResultado> {
     try {
-        await api.post(
+        const response = await api.post(
             "/auth/invite/set-password",
             { token, senha, confirmacao },
             {
@@ -97,7 +97,7 @@ export async function criarSenha(
                 withCredentials: true,
             }
         );
-        return { ok: true };
+        return { ok: true, usuario: response.data?.usuario };
     } catch (error: any) {
         const status = error?.response?.status ?? 0;
         const message =

--- a/frontend/app/services/service_professor.ts
+++ b/frontend/app/services/service_professor.ts
@@ -24,32 +24,18 @@ export async function criarProfessor(
     nome: string,
     email: string
 ): Promise<CriarProfessorResultado> {
-    let criado: InterfaceUsuario;
+    // Criação atômica: o papel PROFESSOR é definido na própria criação (GAP-02-I),
+    // sem o antigo POST+PUT (que deixava o usuário como ALUNO se o PUT falhasse).
     try {
         const response = await api.post(
             `admin/usuarios/criar`,
-            { matricula, nome, email },
-            { headers: { "Content-Type": "application/json" }, withCredentials: true }
-        );
-        criado = response.data;
-    } catch (error: any) {
-        const status = error?.response?.status ?? 0;
-        const message = error?.response?.data?.error ?? "Erro ao criar o professor.";
-        return { ok: false, status, message };
-    }
-
-    try {
-        const response = await api.put(
-            `admin/usuarios/${criado.id}`,
-            { matricula, nome, email, role: Role.PROFESSOR, status: "ATIVO" },
+            { matricula, nome, email, role: Role.PROFESSOR },
             { headers: { "Content-Type": "application/json" }, withCredentials: true }
         );
         return { ok: true, professor: response.data };
     } catch (error: any) {
         const status = error?.response?.status ?? 0;
-        const message =
-            error?.response?.data?.error ??
-            "Usuário criado, mas não foi possível defini-lo como professor.";
+        const message = error?.response?.data?.error ?? "Erro ao criar o professor.";
         return { ok: false, status, message };
     }
 }

--- a/frontend/libs/socket.ts
+++ b/frontend/libs/socket.ts
@@ -1,8 +1,12 @@
 import { io } from "socket.io-client";
 
-const socket = io("http://localhost:5000", {
+const SOCKET_URL = process.env.NEXT_PUBLIC_API_URL_RUNTIME ?? "http://localhost:5000";
+
+const socket = io(SOCKET_URL, {
     autoConnect: false,
-    transports: ["websocket"]
+    transports: ["websocket"],
+    // Envia o cookie de sessão (httponly) no handshake para o backend autenticar.
+    withCredentials: true,
 });
 
 export default socket;

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -18,6 +18,14 @@ export function middleware(request: NextRequest) {
     const token = request.cookies.get("token")?.value;
     const { pathname } = request.nextUrl;
 
+    if (pathname === '/') {
+        if (token) {
+            const role = getRoleFromToken(token);
+            return NextResponse.redirect(new URL(homeForRole(role), request.url));
+        }
+        return NextResponse.redirect(new URL("/login", request.url));
+    }
+
     const isPublicRoute = PUBLIC_ROUTES.some(r => pathname.startsWith(r));
 
     if (isPublicRoute) {


### PR DESCRIPTION
## Resumo

Branch de correções gerais que fecha gaps levantados no relatório épicos × código,
abrangendo autenticação/sessão, gestão de usuários, matérias, e o fluxo de
chat/RAG (embedding + recuperação), além de ajustes de infraestrutura de
desenvolvimento. 

## Mudanças por área

### Autenticação & Sessão (EP-01 / GAP-01)
- Sessão por inatividade, autenticação no handshake do socket e denylist de tokens em Redis (`a57d0e8`)
- Correção de RBAC professor/aluno (GAP-01-A) e sessão no primeiro acesso/reset de senha — US-03-RN3 (`7724469`)
- Botão "Sair" do professor passa a encerrar a sessão de fato — US-05-RI1 (`b68bce8`)
- Validação da confirmação de senha apenas quando enviada (set-password resiliente) (`452a865`)

### Gestão de Usuários (EP-02 / GAP-02)
- Proteção das rotas `/usuarios/*` (GAP-02-A), mensagens de duplicidade específicas e cadastro alinhado ao Figma (`7f0b673`)
- Encerra sessão ao desativar usuário, bloqueia auto-desativação, matrícula imutável, e-mail único na edição e troca de role atômica (`27dfc59`)
- Listagem de alunos paginada e com busca server-side — GAP-02-D / US-08-RNF1/RNF2 (`10bb473`)
- Separação de `RoleEnum` e `StatusEnum` — GAP-02-K (`56f4b0a`)

### Matérias & Turmas (EP-03)
- Código da matéria imutável no backend, mensagem de campos corrigida e confirmação alinhada ao Figma (`674be91`)

### Chat / RAG / Embedding (GAP-06)
- **`busca_semantica`**: corrige `asyncio.to_thread(buscar_no_vector_db(...))` que passava o *resultado* como callable → `TypeError` em toda mensagem com material indexado. Agora passa função+args — GAP-06-B (`1a647aa`)
- **Backend com WebSocket**: troca `flask run` (Werkzeug não faz upgrade de WS → 500 no handshake) por `gunicorn` + `GeventWebSocketWorker`; inclui libs de sistema do OpenCV/Docling (`8eebd98`)
- **`arquivo_id` nos metadados do ChromaDB**: `salvar_documento_vetor` não gravava `arquivo_id`, mas a busca filtra por ele → todo upload ficava invisível ao chat até migração manual. Agora o documento já nasce buscável (`4adc8e7`)
- **Persistência do ChromaDB**: volume nomeado `chroma_data_dev:/data` (antes os vetores eram apagados a cada recreate/rebuild); libs do Docling reordenadas para após o `pip` (não invalida cache das camadas pesadas) (`f835ca4`)

### Diversos
- Corrige 404 em listagens vazias e na rota raiz (`804fd18`)
- Normaliza fim de linha (LF) em scripts shell (`888c48f`)