### PR TITLE
Feature/us 38.4 pull inicializacao

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -74,5 +74,8 @@ app.register_blueprint(admin_bp, url_prefix="/admin")
 app.register_blueprint(auth_bp, url_prefix='/auth')
 app.register_blueprint(llm_bp)
 
+from application.startup import sincronizar_modelos_no_boot
+sincronizar_modelos_no_boot(app)
+
 if __name__ == "__main__":
     socketio.run(app, host="0.0.0.0", port=5000)

--- a/backend/application/services/service_llm.py
+++ b/backend/application/services/service_llm.py
@@ -38,6 +38,14 @@ class AddModelErro(Enum):
     OLLAMA_INDISPONIVEL = "ollama_indisponivel"
 
 
+# Status terminais de um `pull`, gravados no progress store e usados como contrato
+# entre o service e quem observa o resultado (rota de polling e boot da aplicação).
+# Centralizados aqui para evitar strings mágicas espalhadas.
+STATUS_CONCLUIDO = "concluido"
+STATUS_ERRO = "erro"
+STATUS_MODELO_NAO_ENCONTRADO = "modelo_nao_encontrado"
+
+
 # --------------------------------------------------------------------------- #
 # Leitura
 # --------------------------------------------------------------------------- #
@@ -240,7 +248,7 @@ def _percentual_do_evento(evento: dict, percent_atual: int) -> int:
     return int((evento.get("completed") or 0) / total * 100)
 
 
-def pullModel(nome: str, model_id: str) -> None:
+def pullModel(nome: str, model_id: str) -> str:
     """
     Executa o `pull` de um modelo no Ollama e atualiza o progresso (0–100%).
 
@@ -248,9 +256,10 @@ def pullModel(nome: str, model_id: str) -> None:
     - `nome`: str - o nome do modelo no Ollama.
     - `model_id`: str - o ID do registro, usado como chave no progress store.
 
-    Não retorna valor: o resultado é observado via `getPullProgress(model_id)`.
-    O estágio final fica como "concluido" (100%) em sucesso, ou "erro" se o
-    download falhar.
+    Nunca levanta exceção (é seguro chamar numa thread de fundo). Retorna o status
+    terminal: `STATUS_CONCLUIDO` em sucesso, ou `STATUS_ERRO` /
+    `STATUS_MODELO_NAO_ENCONTRADO` em falha. O progresso também fica observável via
+    `getPullProgress(model_id)`.
     """
     percent_atual = 0
     try:
@@ -261,28 +270,44 @@ def pullModel(nome: str, model_id: str) -> None:
             )
 
         # O stream terminou sem erro: o download está completo.
-        llm_progress_store.set_progress(model_id, 100, "concluido")
+        llm_progress_store.set_progress(model_id, 100, STATUS_CONCLUIDO)
+        return STATUS_CONCLUIDO
     except OllamaModelNotFoundError:
-        llm_progress_store.set_progress(model_id, percent_atual, "modelo_nao_encontrado")
+        llm_progress_store.set_progress(model_id, percent_atual, STATUS_MODELO_NAO_ENCONTRADO)
+        return STATUS_MODELO_NAO_ENCONTRADO
     except OllamaIndisponivelError:
-        llm_progress_store.set_progress(model_id, percent_atual, "erro")
+        llm_progress_store.set_progress(model_id, percent_atual, STATUS_ERRO)
+        return STATUS_ERRO
 
 
 def pullAllModels() -> dict:
     """
     Sincroniza todos os modelos cadastrados com o Ollama, executando o `pull`
-    de cada um sequencialmente (uso administrativo/seed).
+    de cada um sequencialmente (uso no boot da aplicação e administrativo).
 
     Diferente de `addModel`, roda de forma síncrona — a intenção é garantir que
     todas as imagens estejam presentes antes de prosseguir.
 
-    Retorna um resumo: {"total": int, "modelos": [nomes processados]}.
+    Retorna um agregado para o chamador decidir o que fazer (ex.: bloquear o boot
+    se houver falhas):
+        {
+            "total": int,
+            "sucessos": [nome, ...],
+            "falhas": [{"nome": str, "status": str}, ...],
+        }
     """
     modelos = getAllModels()
-    for modelo in modelos:
-        pullModel(modelo["nome"], modelo["id"])
+    sucessos: list[str] = []
+    falhas: list[dict] = []
 
-    return {"total": len(modelos), "modelos": [m["nome"] for m in modelos]}
+    for modelo in modelos:
+        status = pullModel(modelo["nome"], modelo["id"])
+        if status == STATUS_CONCLUIDO:
+            sucessos.append(modelo["nome"])
+        else:
+            falhas.append({"nome": modelo["nome"], "status": status})
+
+    return {"total": len(modelos), "sucessos": sucessos, "falhas": falhas}
 
 
 def getPullProgress(model_id: str) -> dict | None:
@@ -304,7 +329,7 @@ def getPullProgress(model_id: str) -> dict | None:
 
     # Sem progresso em memória: distingue "modelo já baixado" de "id inexistente".
     if getModelById(model_id) is not None:
-        return {"percent": 100, "status": "concluido"}
+        return {"percent": 100, "status": STATUS_CONCLUIDO}
 
     return None
 

--- a/backend/application/startup.py
+++ b/backend/application/startup.py
@@ -11,6 +11,7 @@ este código sem um Ollama disponível. Em produção, o docker-compose liga a f
 """
 import logging
 import os
+import sys
 
 from application.services.service_llm import pullAllModels
 
@@ -25,6 +26,10 @@ _VALORES_VERDADEIROS = {"1", "true", "yes", "on"}
 
 def _pull_no_boot_habilitado() -> bool:
     """Indica se o pull de modelos no boot está habilitado pela variável de ambiente."""
+    # Comandos de migração (`flask db ...`) importam o app antes de a tabela `llm`
+    # existir; nesse caso o pull não pode rodar — evita o problema ovo-e-galinha.
+    if len(sys.argv) > 1 and sys.argv[1] == "db":
+        return False
     return os.getenv(FLAG_PULL_NO_BOOT, "").strip().lower() in _VALORES_VERDADEIROS
 
 

--- a/backend/application/startup.py
+++ b/backend/application/startup.py
@@ -1,0 +1,81 @@
+"""
+Rotinas de inicialização (boot) da aplicação.
+
+Concentra aqui o que precisa rodar uma única vez, ao subir o servidor, antes de
+ele atender requisições. Hoje: sincronizar com o Ollama todos os modelos de IA
+cadastrados no banco (US-38.4).
+
+A sincronização é **opt-in** por variável de ambiente para não disparar durante a
+suíte de testes nem no `flask run` local — onde `from app import app` executaria
+este código sem um Ollama disponível. Em produção, o docker-compose liga a flag.
+"""
+import logging
+import os
+
+from application.services.service_llm import pullAllModels
+
+logger = logging.getLogger(__name__)
+
+# Variável de ambiente que habilita o pull no boot. Ligada no docker-compose do
+# deploy; ausente/desligada em testes e desenvolvimento local.
+FLAG_PULL_NO_BOOT = "PULL_MODELS_ON_STARTUP"
+
+_VALORES_VERDADEIROS = {"1", "true", "yes", "on"}
+
+
+def _pull_no_boot_habilitado() -> bool:
+    """Indica se o pull de modelos no boot está habilitado pela variável de ambiente."""
+    return os.getenv(FLAG_PULL_NO_BOOT, "").strip().lower() in _VALORES_VERDADEIROS
+
+
+def _logar_resultado_pull(resultado: dict) -> None:
+    """Registra nos logs o status de cada pull (sucesso em info, falha em error)."""
+    for nome in resultado["sucessos"]:
+        logger.info("Pull concluído: modelo '%s' sincronizado.", nome)
+
+    for falha in resultado["falhas"]:
+        logger.error(
+            "Pull falhou: modelo '%s' (status: %s).", falha["nome"], falha["status"]
+        )
+
+
+def sincronizar_modelos_no_boot(app) -> None:
+    """
+    Sincroniza com o Ollama todos os modelos cadastrados, durante a inicialização.
+
+    Regras (US-38.4):
+    - Só executa se a flag `PULL_MODELS_ON_STARTUP` estiver ligada (caso contrário,
+      é um no-op — protege testes e dev local).
+    - Registra nos logs o status de cada pull realizado.
+    - Se algum pull falhar, levanta `RuntimeError` para **bloquear a inicialização**
+      até o problema ser resolvido (a aplicação não deve atender requisições com
+      modelos dessincronizados).
+
+    Espera receber:
+    - `app`: a instância Flask, para abrir o app_context necessário ao acesso ao banco.
+    """
+    if not _pull_no_boot_habilitado():
+        logger.debug(
+            "Pull de modelos no boot desabilitado (defina %s para habilitar).",
+            FLAG_PULL_NO_BOOT,
+        )
+        return
+
+    logger.info("Sincronizando modelos de IA com o Ollama na inicialização...")
+
+    # pullAllModels consulta o banco (getAllModels), então precisa de app_context.
+    with app.app_context():
+        resultado = pullAllModels()
+
+    _logar_resultado_pull(resultado)
+
+    if resultado["falhas"]:
+        nomes_falha = ", ".join(falha["nome"] for falha in resultado["falhas"])
+        raise RuntimeError(
+            "Inicialização bloqueada: falha ao sincronizar com o Ollama os modelos: "
+            f"{nomes_falha}. Resolva o problema e reinicie a aplicação."
+        )
+
+    logger.info(
+        "Sincronização concluída: %d modelo(s) prontos.", len(resultado["sucessos"])
+    )

--- a/backend/application/tests/services/test_service_llm_pull.py
+++ b/backend/application/tests/services/test_service_llm_pull.py
@@ -173,9 +173,31 @@ def test_pull_all_models_sincroniza_todos(ctx):
         resumo = service_llm.pullAllModels()
 
     assert resumo["total"] == 2
-    assert set(resumo["modelos"]) == {"llama3", "mistral"}
+    assert set(resumo["sucessos"]) == {"llama3", "mistral"}
+    assert resumo["falhas"] == []
     assert llm_progress_store.get_progress(id_a)["percent"] == 100
     assert llm_progress_store.get_progress(id_b)["percent"] == 100
+
+
+def test_pull_all_models_reporta_falhas(ctx):
+    """Modelos que falham no pull devem aparecer em 'falhas', não em 'sucessos'."""
+    _criar_llm("llama3")
+    _criar_llm("nao-existe")
+
+    def _pull_por_modelo(nome):
+        if nome == "nao-existe":
+            raise OllamaModelNotFoundError("not found")
+        return _fake_pull_eventos()
+
+    with patch.object(
+        service_llm.repository_ollama, "pull_model", side_effect=_pull_por_modelo
+    ):
+        resumo = service_llm.pullAllModels()
+
+    assert resumo["sucessos"] == ["llama3"]
+    assert resumo["falhas"] == [
+        {"nome": "nao-existe", "status": service_llm.STATUS_MODELO_NAO_ENCONTRADO}
+    ]
 
 
 # --------------------------------------------------------------------------- #

--- a/backend/application/tests/services/test_startup_pull.py
+++ b/backend/application/tests/services/test_startup_pull.py
@@ -1,0 +1,92 @@
+"""
+Testes do fluxo de pull dos modelos na inicialização (US-38.4).
+
+Exercita `sincronizar_modelos_no_boot` diretamente (sem importar `app`), com
+`pullAllModels` mockado — assim cobrimos todos os critérios de aceitação sem tocar
+no Ollama nem no banco.
+"""
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from application import startup
+
+
+def _app_falso() -> MagicMock:
+    """App fake cujo `app_context()` funciona como context manager (no-op)."""
+    return MagicMock()
+
+
+def test_no_op_quando_flag_desligada(monkeypatch):
+    """
+    Sem a flag, o boot NÃO deve chamar pullAllModels — é o que protege a suíte de
+    testes e o `flask run` local de dispararem downloads.
+    """
+    monkeypatch.delenv(startup.FLAG_PULL_NO_BOOT, raising=False)
+
+    with patch.object(startup, "pullAllModels") as mock_pull:
+        startup.sincronizar_modelos_no_boot(_app_falso())
+
+    mock_pull.assert_not_called()
+
+
+def test_chama_pull_all_models_quando_flag_ligada(monkeypatch):
+    """Com a flag ligada, o boot deve sincronizar via pullAllModels."""
+    monkeypatch.setenv(startup.FLAG_PULL_NO_BOOT, "true")
+
+    with patch.object(
+        startup, "pullAllModels",
+        return_value={"total": 1, "sucessos": ["llama3"], "falhas": []},
+    ) as mock_pull:
+        startup.sincronizar_modelos_no_boot(_app_falso())
+
+    mock_pull.assert_called_once()
+
+
+def test_bloqueia_inicializacao_quando_ha_falha(monkeypatch):
+    """Qualquer falha de pull deve levantar RuntimeError (bloqueia o boot)."""
+    monkeypatch.setenv(startup.FLAG_PULL_NO_BOOT, "1")
+
+    resultado = {
+        "total": 2,
+        "sucessos": ["llama3"],
+        "falhas": [{"nome": "nao-existe", "status": "modelo_nao_encontrado"}],
+    }
+
+    with patch.object(startup, "pullAllModels", return_value=resultado):
+        with pytest.raises(RuntimeError, match="nao-existe"):
+            startup.sincronizar_modelos_no_boot(_app_falso())
+
+
+def test_nao_bloqueia_quando_todos_concluem(monkeypatch):
+    """Sem falhas, a inicialização segue normalmente (sem exceção)."""
+    monkeypatch.setenv(startup.FLAG_PULL_NO_BOOT, "on")
+
+    resultado = {"total": 2, "sucessos": ["llama3", "mistral"], "falhas": []}
+
+    with patch.object(startup, "pullAllModels", return_value=resultado):
+        # Não deve levantar.
+        startup.sincronizar_modelos_no_boot(_app_falso())
+
+
+def test_loga_status_de_cada_pull(monkeypatch, caplog):
+    """Os logs de inicialização devem mostrar o status de cada pull (sucesso/falha)."""
+    monkeypatch.setenv(startup.FLAG_PULL_NO_BOOT, "true")
+
+    resultado = {
+        "total": 2,
+        "sucessos": ["llama3"],
+        "falhas": [{"nome": "nao-existe", "status": "erro"}],
+    }
+
+    with patch.object(startup, "pullAllModels", return_value=resultado):
+        with caplog.at_level(logging.INFO, logger="application.startup"):
+            with pytest.raises(RuntimeError):
+                startup.sincronizar_modelos_no_boot(_app_falso())
+
+    texto = caplog.text
+    assert "llama3" in texto                       # status de sucesso logado
+    assert "nao-existe" in texto                   # status de falha logado
+    # A falha precisa ser registrada em nível de erro.
+    assert any(r.levelno == logging.ERROR for r in caplog.records)

--- a/backend/application/tests/services/test_startup_pull.py
+++ b/backend/application/tests/services/test_startup_pull.py
@@ -31,6 +31,21 @@ def test_no_op_quando_flag_desligada(monkeypatch):
     mock_pull.assert_not_called()
 
 
+def test_no_op_durante_migracao_mesmo_com_flag_ligada(monkeypatch):
+    """
+    Mesmo com a flag ligada, comandos `flask db ...` (ex.: o `flask db upgrade` do
+    entrypoint) NÃO devem disparar o pull — a tabela `llm` ainda não existe nesse
+    momento (problema ovo-e-galinha).
+    """
+    monkeypatch.setenv(startup.FLAG_PULL_NO_BOOT, "true")
+    monkeypatch.setattr(startup.sys, "argv", ["flask", "db", "upgrade"])
+
+    with patch.object(startup, "pullAllModels") as mock_pull:
+        startup.sincronizar_modelos_no_boot(_app_falso())
+
+    mock_pull.assert_not_called()
+
+
 def test_chama_pull_all_models_quando_flag_ligada(monkeypatch):
     """Com a flag ligada, o boot deve sincronizar via pullAllModels."""
     monkeypatch.setenv(startup.FLAG_PULL_NO_BOOT, "true")

--- a/backend/migrations/versions/a1b2c3d4e5f6_adiciona_coluna_status_na_tabela_llm.py
+++ b/backend/migrations/versions/a1b2c3d4e5f6_adiciona_coluna_status_na_tabela_llm.py
@@ -1,0 +1,36 @@
+"""adiciona coluna status na tabela llm
+
+Revision ID: a1b2c3d4e5f6
+Revises: 63125fcdb5a0
+Create Date: 2026-06-20 12:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'a1b2c3d4e5f6'
+down_revision = '63125fcdb5a0'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # A coluna `status` existe no model LLM (model_llm.py) desde a US-38, mas nenhuma
+    # migração a criava — o schema migrado tinha apenas `id` e `nome`. Como o model
+    # usa `native_enum=False`, é um VARCHAR simples (sem TYPE nativo no Postgres).
+    # `server_default` garante o NOT NULL em linhas já existentes.
+    op.add_column(
+        'llm',
+        sa.Column(
+            'status',
+            sa.Enum('ativada', 'desativada', name='llmstatusenum', native_enum=False),
+            nullable=False,
+            server_default='desativada',
+        ),
+    )
+
+
+def downgrade():
+    op.drop_column('llm', 'status')

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,9 @@ services:
     environment:
       - OLLAMA_HOST=http://ollama-service:11434
       - REDIS_URL=redis://redis-service:6379/0
+      # Sincroniza os modelos de IA com o Ollama no boot (US-38.4). Bloqueia a
+      # inicialização se algum pull falhar.
+      - PULL_MODELS_ON_STARTUP=true
     depends_on:
       - postgres-service
       - ollama-service


### PR DESCRIPTION
###  Resumo da Entrega (US-38.4)
Nesta PR, implementamos a funcionalidade que garante que o sistema realize o *pull* de todos os modelos de IA salvos no banco de dados logo durante a inicialização, garantindo que a plataforma só fique acessível após a sincronização com o Ollama estar concluída.

###  O que foi feito e Como resolvemos:
1. **Fluxo de Inicialização Seguro:** Injetamos a chamada do método `pullAllModels()` no arquivo `startup.py`, antes do carregamento do Gunicorn. Se houver falha, a inicialização é bloqueada e logada, cumprindo todos os Critérios de Aceitação.
2. **Solução do Problema "Ovo e Galinha" (Bloqueio do Alembic):** Durante o desenvolvimento, identificamos que o boot interceptava comandos de linha de comando (`flask db upgrade`), causando quebra pois a tabela `llm` tentava ser consultada antes de ser criada.
   * **A Solução:** Adicionamos um *Guard* (`sys.argv`) no `startup.py`. Agora, o sistema reconhece quando o boot é apenas para rodar migrações e pula a etapa do Ollama temporariamente, permitindo que o banco seja montado em paz.
3. **Correção de Débito Técnico (Schema Drift):** Identificamos que a coluna `status` (Enum) da tabela `llm` havia sido adicionada no Model em tarefas anteriores, mas sua migração nunca foi gerada, quebrando o banco em ambientes zerados.
   * **A Solução:** Mapeamos a cadeia (HEAD) do Alembic e criamos o arquivo de migração exato (`a1b2c3d4e5f6`) que constrói a coluna `status`, estabilizando a infraestrutura do projeto de vez.

### 📸 Evidências
*<img width="1486" height="395" alt="Passou" src="https://github.com/user-attachments/assets/91a4e13b-acb2-4a00-a0b8-f9669daea88e" />*
**Docker:** Prova que a aplicação sobe lisa, não trava no banco de dados, e que a inicialização acontece da forma correta.
*<img width="1834" height="747" alt="US 38 4" src="https://github.com/user-attachments/assets/8ab392bf-c0d5-48e7-a576-f36ac10ef971" />*
**Testes:** Prova que passou nos 21 testes de qualidade do test_startup_pull.py



